### PR TITLE
Adding ro-cert-manager to incubator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             go get sigs.k8s.io/kind
             cp /go/bin/kind /binaries/kind
       - save_cache:
-          key: v1-binaries
+          key: v2-binaries
           paths:
             - /binaries
   lint-scripts:
@@ -59,7 +59,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-binaries
+            - v2-binaries
       - setup_remote_docker
       - *setup_environment
       - run:

--- a/incubator/ro-cert-manager/.gitignore
+++ b/incubator/ro-cert-manager/.gitignore
@@ -1,0 +1,2 @@
+requirements.lock
+charts/

--- a/incubator/ro-cert-manager/CODEOWNERS
+++ b/incubator/ro-cert-manager/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sudermanjr @endzyme

--- a/incubator/ro-cert-manager/Chart.yaml
+++ b/incubator/ro-cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: ro-cert-manager
 apiVersion: v1
-version: v1.1.1
+version: v2.0.0
 appVersion: v0.5.0
 description: Install cert-manager and setup CA cluster-issuers
 maintainers:

--- a/incubator/ro-cert-manager/Chart.yaml
+++ b/incubator/ro-cert-manager/Chart.yaml
@@ -1,0 +1,8 @@
+name: ro-cert-manager
+apiVersion: v1
+version: v1.1.1
+appVersion: v0.5.0
+description: Install cert-manager and setup CA cluster-issuers
+maintainers:
+  - name: sudermanjr
+  - name: endzyme

--- a/incubator/ro-cert-manager/README.md
+++ b/incubator/ro-cert-manager/README.md
@@ -1,0 +1,23 @@
+# Chart - ro-cert-manager
+
+Installs the necessary additional items that the cert-manager chart lacks.
+
+## Configuration
+
+The following table lists the configurable parameters of the chart and their default values.
+
+| Parameter | Description | Default | Required |
+| --------- | ----------- | ------- | -------- |
+| `cert-manager.enabled` | Install the cert-manager chart as a dependency | `true` | yes |
+| `clusterIssuers.staging.clusterIssuerName` | Name of the staging clusterIssuer | `Release.Name-staging-self-signed` | no |
+| `clusterIssuers.staging.enabled` | Whether or not the staging ClusterIssuer is installed | `true` | yes |
+| `clusterIssuers.staging.issuerUrl` | The URL to use for ACME | `https://acme-staging-v02.api.letsencrypt.org/directory` | no |
+| `clusterIssuers.staging.http.enabled` | Enables http01 validation on staging issuer | `false` | yes |
+| `clusterIssuers.staging.dns.enabled` | Enables dns01 validation on staging issuer. See [values.yaml](values.yaml) for configuration. | `false` | yes |
+| `clusterIssuers.production.clusterIssuerName` | Name of the production clusterIssuer | `Release.Name-production-valid` | no |
+| `clusterIssuers.production.enabled` | Whether or not the production ClusterIssuer is installed | `true` | yes |
+| `clusterIssuers.production.issuerUrl` | The URL to use for ACME | `https://acme-v02.api.letsencrypt.org/directory` | no |
+| `clusterIssuers.production.http.enabled` | Enables http01 validation on production issuer | `false` | yes |
+| `clusterIssuers.production.dns.enabled` | Enables dns01 validation on production issuer. See [values.yaml](values.yaml) for configuration. | `false` | yes |
+
+

--- a/incubator/ro-cert-manager/requirements.yaml
+++ b/incubator/ro-cert-manager/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+  - name: cert-manager
+    version: 0.5.2
+    repository: https://kubernetes-charts.storage.googleapis.com
+    condition: cert-manager.enabled

--- a/incubator/ro-cert-manager/templates/_helpers.tpl
+++ b/incubator/ro-cert-manager/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "common-labels" }}
+chart: {{ .Chart.Name }}
+release: {{ .Release.Name }}
+heritage: {{ .Release.Service }}
+{{- end }}

--- a/incubator/ro-cert-manager/templates/production-valid.cluster-issuer.yaml
+++ b/incubator/ro-cert-manager/templates/production-valid.cluster-issuer.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.clusterIssuers.production.enabled }}
+{{- $globalScope := . }}
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: {{ .Values.clusterIssuers.production.clusterIssuerName | default (printf "%s-production-valid" .Release.Name) }}
+  labels:
+{{- include "common-labels" . | indent 4 }}
+{{- with .Values.clusterIssuers.production }}
+spec:
+  acme:
+    # The ACME staging server URL
+    server: {{ .issuerUrl | default "https://acme-v02.api.letsencrypt.org/directory" }}
+    # Email address used for ACME registration
+    email: {{ .email | quote }}
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: {{ $globalScope.Release.Name }}-production-private-key
+    {{- if .http.enabled }}
+    http01: {}
+    {{- end }}
+    {{- if .dns.enabled }}
+    dns01:
+      providers:
+      {{- with .dns.googleCloudDNS }}
+      - name: {{ .name | default "clouddns" }}
+        clouddns:
+        {{- if .secretName }}
+          serviceAccountSecretRef:
+            name: {{ .secretName }}
+            key: {{ .secretKey }}
+        {{- end }}
+          project: {{ .gcpProject }}
+      {{- end }}
+      {{- with .dns.amazonRoute53 }}
+      - name: {{ .name | default "route53" }}
+        route53:
+          region: {{ .region }}
+          {{- if .hostedZoneID }}
+          hostedZoneID: {{ .hostedZoneID }}
+          {{- end }}
+          {{- if .secretName }}
+          accessKeyID: {{ .accessKeyID }}
+          secretAccessKeySecretRef:
+            name: {{ .secretName }}
+            key: {{ .secretKey }}
+          {{- end }}
+      {{- end }}
+      {{- if .dns.inlineProviderConfigs }}
+{{ toYaml .dns.inlineProviderConfigs | indent 6 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/incubator/ro-cert-manager/templates/staging-self-signed.cluster-issuer.yaml
+++ b/incubator/ro-cert-manager/templates/staging-self-signed.cluster-issuer.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.clusterIssuers.staging.enabled }}
+{{- $globalScope := . }}
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: {{ .Values.clusterIssuers.staging.clusterIssuerName | default (printf "%s-staging-self-signed" .Release.Name) }}
+  labels:
+{{- include "common-labels" . | indent 4 }}
+{{- with .Values.clusterIssuers.staging }}
+spec:
+  acme:
+    # The ACME staging server URL
+    server: {{ .issuerUrl | default "https://acme-staging-v02.api.letsencrypt.org/directory" }}
+    # Email address used for ACME registration
+    email: {{ .email | quote }}
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: {{ $globalScope.Release.Name }}-staging-private-key
+    {{- if .http.enabled }}
+    http01: {}
+    {{- end }}
+    {{- if .dns.enabled }}
+    dns01:
+      providers:
+      {{- with .dns.googleCloudDNS }}
+      - name: {{ .name | default "clouddns" }}
+        clouddns:
+        {{- if .secretName }}
+          serviceAccountSecretRef:
+            name: {{ .secretName }}
+            key: {{ .secretKey }}
+        {{- end }}
+          project: {{ .gcpProject }}
+      {{- end }}
+      {{- with .dns.amazonRoute53 }}
+      - name: {{ .name | default "route53" }}
+        route53:
+          region: {{ .region }}
+          {{- if .hostedZoneID }}
+          hostedZoneID: {{ .hostedZoneID }}
+          {{- end }}
+          {{- if .secretName }}
+          accessKeyID: {{ .accessKeyID }}
+          secretAccessKeySecretRef:
+            name: {{ .secretName }}
+            key: {{ .secretKey }}
+          {{- end }}
+
+      {{- end }}
+      {{- if .dns.inlineProviderConfigs }}
+{{ toYaml .dns.inlineProviderConfigs | indent 6 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/incubator/ro-cert-manager/values.yaml
+++ b/incubator/ro-cert-manager/values.yaml
@@ -1,0 +1,90 @@
+# Cluster issuers
+# The configuration of cluster issuers to setup for cert-manager
+
+# Install the cert-manager for me.
+cert-manager:
+  enabled: true
+
+clusterIssuers:
+  staging:
+    # clusterIssuerName: "" #optional
+    enabled: true
+    email: someone@example.com
+    # issuerUrl: "" # Predefined for LetsEncrypt staging
+    http:
+      enabled: false
+    dns:
+      # flag to enable/disable all dns configs
+      enabled: false
+
+      # Google ClouDNS configurations (optional)
+      #
+      # Please note that this chart does not create the service account or the
+      # kubernetes secret. You will need to go into GCP Project and create an
+      # iam service account that can administrate CloudDNS, then take the service
+      # account key and put into kubernetes.
+      #
+      # googleCloudDNS:
+      #   name: clouddns                                 # name of provider for kind: Certificate resource
+      #   secretName: my-dns-service-account-kube-secret # optional kubernetes secret name in same namespace
+      #   secretKey: credentials.json                    # key in the kubernetes secret with the service account creds
+      #   gcpProject: myprojectname
+
+      # Amazon Route53 configurations (optional)
+      #
+      # amazonRoute53:
+      #   name: route53                                   # name of provider for kind: Certificate resource
+      #   region: us-east-2
+      #   hostedZoneID: somethingsomethingplaceholder
+      #   secretName: my-aws-credentials-kube-secret
+      #   secretKey: key in the secret with the credentials
+      #   accessKeyID: my-aws-key-id
+
+      # Inline provider configs provide the ability to define the provider block directly
+      # instead of abstacting it
+      #
+      # inlineProviderConfigs:
+      # - name: mycustomprovider
+      #   someprovider:
+      #     someparamOne: abc
+      #     someparamTwo: xyz
+
+  production:
+    # clusterIssuerName: "" #optional
+    enabled: true
+    email: someone@example.com
+    # issuerUrl: "" # Predefined for LetsEncrypt production
+    http:
+      enabled: false
+    dns:
+      # flag to enable/disable all dns configs
+      enabled: false
+
+      # Google ClouDNS configurations (optional)
+      #
+      # Please note that this chart does not create the service account or the
+      # kubernetes secret. You will need to go into GCP Project and create an
+      # iam service account that can administrate CloudDNS, then take the service
+      # account key and put into kubernetes.
+      #
+      # googleCloudDNS:
+      #   name: clouddns                                  # name of provider for kind: Certificate resource
+      #   secretName: my-dns-service-account-kube-secret # kubernetes secret name in same namespace
+      #   secretKey: credentials.json                    # key in the kubernetes secret with the service account creds
+      #   gcpProject: myprojectname
+
+      # Amazon Route53 configurations (optional)
+      #
+      # amazonRoute53:
+      #   name: route53                                   # name of provider for kind: Certificate resource
+      #   region: us-east-2
+      #   hostedZoneID: somethingsomethingplaceholder
+
+      # Inline provider configs provide the ability to define the provider block directly
+      # instead of abstacting it
+      #
+      # inlineProviderConfigs:
+      # - name: mycustomprovider
+      #   someprovider:
+      #     someparamOne: abc
+      #     someparamTwo: xyz


### PR DESCRIPTION
Added the ability to install cert-manager as a sub-chart.  This will make it so we can just install one chart.  Bumped to version 2.0.0 to cover this major change.