### PR TITLE
add jetstack repo to ci scripts for dependencies

### DIFF
--- a/scripts/repo-sync-fw.sh
+++ b/scripts/repo-sync-fw.sh
@@ -22,6 +22,7 @@ readonly HELM_URL=https://storage.googleapis.com/kubernetes-helm
 readonly HELM_TARBALL=helm-v2.12.3-linux-amd64.tar.gz
 readonly STABLE_REPO_URL=https://charts.fairwinds.com/stable/
 readonly INCUBATOR_REPO_URL=https://charts.fairwinds.com/incubator/
+readonly JETSTACK_REPO_URL=https://charts.jetstack.io
 readonly S3_BUCKET_STABLE=s3://charts.fairwinds.com/stable
 readonly S3_BUCKET_INCUBATOR=s3://charts.fairwinds.com/incubator
 
@@ -48,6 +49,7 @@ setup_helm_client() {
     helm init --client-only
     helm repo add fairwinds-stable "$STABLE_REPO_URL"
     helm repo add fairwinds-incubator "$INCUBATOR_REPO_URL"
+    helm repo add jetstack "$JETSTACK_REPO_URL"
 }
 
 authenticate() {

--- a/scripts/repo-sync.sh
+++ b/scripts/repo-sync.sh
@@ -22,6 +22,7 @@ readonly HELM_URL=https://storage.googleapis.com/kubernetes-helm
 readonly HELM_TARBALL=helm-v2.12.3-linux-amd64.tar.gz
 readonly STABLE_REPO_URL=https://charts.reactiveops.com/stable/
 readonly INCUBATOR_REPO_URL=https://charts.reactiveops.com/incubator/
+readonly JETSTACK_REPO_URL=https://charts.jetstack.io
 readonly S3_BUCKET_STABLE=s3://charts.reactiveops.com/stable
 readonly S3_BUCKET_INCUBATOR=s3://charts.reactiveops.com/incubator
 
@@ -48,6 +49,7 @@ setup_helm_client() {
     helm init --client-only
     helm repo add reactiveops-stable "$STABLE_REPO_URL"
     helm repo add reactiveops-incubator "$INCUBATOR_REPO_URL"
+    helm repo add jetstack "$JETSTACK_REPO_URL"
 }
 
 authenticate() {


### PR DESCRIPTION
Added the jetstack charts repo to the Ci scripts so it can pull dependencies.  Without this ro-cert-manager was unable to sync:

```
Error: no repository definition for https://charts.jetstack.io. Please add them via 'helm repo add'
ERROR: Problem building dependencies. Skipping packaging of 'incubator/ro-cert-manager'.
```