### PR TITLE
[insights-agent] allow specifying pluto target versions

### DIFF
--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 1.14.5
+version: 1.14.6
 appVersion: 3.2.0
 maintainers:
   - name: rbren

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -100,4 +100,4 @@ Parameter | Description | Default
 `resourcemetrics.installPrometheus` | Install a new Prometheus instance for the resourcemetrics report | false
 `resourcemetrics.address` | The address of an existing Prometheus instance to query in the form `<scheme>://<service-name>.<namespace>[:<port>]` for example `http://prometheus-server.prometheus` | `"http://prometheus-server"`
 `nova.logLevel` | The klog log-level to use when running Nova | `3`
-`pluto.targetVersion` | The Kubernetes version to target | Defaults to current Kubernetes version
+`pluto.targetVersions` | The versions to target, e.g. `k8s=1.21.0` | Defaults to current Kubernetes version

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -100,3 +100,4 @@ Parameter | Description | Default
 `resourcemetrics.installPrometheus` | Install a new Prometheus instance for the resourcemetrics report | false
 `resourcemetrics.address` | The address of an existing Prometheus instance to query in the form `<scheme>://<service-name>.<namespace>[:<port>]` for example `http://prometheus-server.prometheus` | `"http://prometheus-server"`
 `nova.logLevel` | The klog log-level to use when running Nova | `3`
+`pluto.targetVersion` | The Kubernetes version to target | Defaults to current Kubernetes version

--- a/stable/insights-agent/templates/pluto/cronjob.yaml
+++ b/stable/insights-agent/templates/pluto/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
             args:
             - -c
             - |
-              /pluto detect-helm -ojson --target-versions {{ $.Values.pluto.targetVersion | default (printf "k8s=%s" .Capabilities.KubeVersion.Version) }} > /output/pluto-tmp.json
+              /pluto detect-helm -ojson --target-versions {{ $.Values.pluto.targetVersion | default (printf "k8s=v%s.%s.0" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor) }} > /output/pluto-tmp.json
               cat /output/pluto-tmp.json
               mv /output/pluto-tmp.json /output/pluto.json
             {{ include "security-context" . | indent 12 | trim }}

--- a/stable/insights-agent/templates/pluto/cronjob.yaml
+++ b/stable/insights-agent/templates/pluto/cronjob.yaml
@@ -12,8 +12,13 @@ spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
-            command: ["/bin/sh", "-c"]
-            args: ["/pluto detect-helm -ojson > /output/pluto-tmp.json; mv /output/pluto-tmp.json /output/pluto.json"]
+            command: ["/bin/sh"]
+            args:
+            - -c
+            - |
+              /pluto detect-helm -ojson --target-versions {{ $.Values.pluto.targetVersion | default (printf "k8s=%s" .Capabilities.KubeVersion.Version) }} > /output/pluto-tmp.json
+              cat /output/pluto-tmp.json
+              mv /output/pluto-tmp.json /output/pluto.json
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/templates/pluto/cronjob.yaml
+++ b/stable/insights-agent/templates/pluto/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
             args:
             - -c
             - |
-              /pluto detect-helm -ojson --target-versions {{ $.Values.pluto.targetVersion | default (printf "k8s=v%s.%s.0" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor) }} > /output/pluto-tmp.json
+              /pluto detect-helm -ojson --target-versions {{ $.Values.pluto.targetVersions | default (printf "k8s=v%s.%s.0" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor) }} > /output/pluto-tmp.json
               cat /output/pluto-tmp.json
               mv /output/pluto-tmp.json /output/pluto.json
             {{ include "security-context" . | indent 12 | trim }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -263,6 +263,7 @@ pluto:
   enabled: false
   schedule: "rand * * * *"
   timeout: 300
+  targetVersions: ""
   image:
     repository: quay.io/fairwinds/pluto
     tag: "v5.0"


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
