### PR TITLE
Update vpa crd version

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 0.4.4
+version: 0.5.0
 appVersion: 0.9.2
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/crds/vpa-v1-crd.yaml
+++ b/stable/vpa/crds/vpa-v1-crd.yaml
@@ -1,94 +1,800 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: verticalpodautoscalers.autoscaling.k8s.io
   annotations:
-    "api-approved.kubernetes.io": "https://github.com/kubernetes/kubernetes/pull/63797"
+    api-approved.kubernetes.io: https://github.com/kubernetes/kubernetes/pull/63797
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: verticalpodautoscalers.autoscaling.k8s.io
 spec:
   group: autoscaling.k8s.io
-  scope: Namespaced
   names:
-    plural: verticalpodautoscalers
-    singular: verticalpodautoscaler
     kind: VerticalPodAutoscaler
+    listKind: VerticalPodAutoscalerList
+    plural: verticalpodautoscalers
     shortNames:
       - vpa
-  version: v1beta1
+    singular: verticalpodautoscaler
+  scope: Namespaced
   versions:
-    - name: v1beta1
-      served: false
-      storage: false
-    - name: v1beta2
+    - additionalPrinterColumns:
+        - jsonPath: .spec.updatePolicy.updateMode
+          name: Mode
+          type: string
+        - jsonPath: .status.recommendation.containerRecommendations[0].target.cpu
+          name: CPU
+          type: string
+        - jsonPath: .status.recommendation.containerRecommendations[0].target.memory
+          name: Mem
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='RecommendationProvided')].status
+          name: Provided
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description:
+            VerticalPodAutoscaler is the configuration for a vertical pod
+            autoscaler, which automatically manages pod resources based on historical
+            and real time resource utilization.
+          properties:
+            apiVersion:
+              description:
+                "APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description:
+                "Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                "Specification of the behavior of the autoscaler. More info:
+                https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status."
+              properties:
+                resourcePolicy:
+                  description:
+                    Controls how the autoscaler computes recommended resources.
+                    The resource policy may be used to set constraints on the recommendations
+                    for individual containers. If not specified, the autoscaler computes
+                    recommended resources for all containers in the pod, without additional
+                    constraints.
+                  properties:
+                    containerPolicies:
+                      description: Per-container resource policies.
+                      items:
+                        description:
+                          ContainerResourcePolicy controls how autoscaler
+                          computes the recommended resources for a specific container.
+                        properties:
+                          containerName:
+                            description:
+                              Name of the container or DefaultContainerResourcePolicy,
+                              in which case the policy is used by the containers that
+                              don't have their own policy specified.
+                            type: string
+                          controlledResources:
+                            description:
+                              Specifies the type of recommendations that
+                              will be computed (and possibly applied) by VPA. If not
+                              specified, the default of [ResourceCPU, ResourceMemory]
+                              will be used.
+                            items:
+                              description:
+                                ResourceName is the name identifying various
+                                resources in a ResourceList.
+                              type: string
+                            type: array
+                          controlledValues:
+                            description:
+                              Specifies which resource values should be controlled.
+                              The default is "RequestsAndLimits".
+                            enum:
+                              - RequestsAndLimits
+                              - RequestsOnly
+                            type: string
+                          maxAllowed:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description:
+                              Specifies the maximum amount of resources that
+                              will be recommended for the container. The default is
+                              no maximum.
+                            type: object
+                          minAllowed:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description:
+                              Specifies the minimal amount of resources that
+                              will be recommended for the container. The default is
+                              no minimum.
+                            type: object
+                          mode:
+                            description:
+                              Whether autoscaler is enabled for the container.
+                              The default is "Auto".
+                            enum:
+                              - Auto
+                              - "Off"
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                targetRef:
+                  description:
+                    TargetRef points to the controller managing the set of
+                    pods for the autoscaler to control - e.g. Deployment, StatefulSet.
+                    VerticalPodAutoscaler can be targeted at controller implementing
+                    scale subresource (the pod set is retrieved from the controller's
+                    ScaleStatus) or some well known controllers (e.g. for DaemonSet
+                    the pod set is read from the controller's spec). If VerticalPodAutoscaler
+                    cannot use specified target it will report ConfigUnsupported condition.
+                    Note that VerticalPodAutoscaler does not require full implementation
+                    of scale subresource - it will not use it to modify the replica
+                    count. The only thing retrieved is a label selector matching pods
+                    grouped by the target resource.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+                      type: string
+                  required:
+                    - kind
+                    - name
+                  type: object
+                updatePolicy:
+                  description:
+                    Describes the rules on how changes are applied to the
+                    pods. If not specified, all fields in the `PodUpdatePolicy` are
+                    set to their default values.
+                  properties:
+                    updateMode:
+                      description:
+                        Controls when autoscaler applies changes to the pod
+                        resources. The default is 'Auto'.
+                      enum:
+                        - "Off"
+                        - Initial
+                        - Recreate
+                        - Auto
+                      type: string
+                  type: object
+              required:
+                - targetRef
+              type: object
+            status:
+              description: Current information about the autoscaler.
+              properties:
+                conditions:
+                  description:
+                    Conditions is the set of conditions required for this
+                    autoscaler to scale its target, and indicates whether or not those
+                    conditions are met.
+                  items:
+                    description:
+                      VerticalPodAutoscalerCondition describes the state
+                      of a VerticalPodAutoscaler at a certain point.
+                    properties:
+                      lastTransitionTime:
+                        description:
+                          lastTransitionTime is the last time the condition
+                          transitioned from one status to another
+                        format: date-time
+                        type: string
+                      message:
+                        description:
+                          message is a human-readable explanation containing
+                          details about the transition
+                        type: string
+                      reason:
+                        description: reason is the reason for the condition's last transition.
+                        type: string
+                      status:
+                        description:
+                          status is the status of the condition (True, False,
+                          Unknown)
+                        type: string
+                      type:
+                        description: type describes the current condition
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                recommendation:
+                  description:
+                    The most recently computed amount of resources recommended
+                    by the autoscaler for the controlled pods.
+                  properties:
+                    containerRecommendations:
+                      description:
+                        Resources recommended by the autoscaler for each
+                        container.
+                      items:
+                        description:
+                          RecommendedContainerResources is the recommendation
+                          of resources computed by autoscaler for a specific container.
+                          Respects the container resource policy if present in the spec.
+                          In particular the recommendation is not produced for containers
+                          with `ContainerScalingMode` set to 'Off'.
+                        properties:
+                          containerName:
+                            description: Name of the container.
+                            type: string
+                          lowerBound:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description:
+                              Minimum recommended amount of resources. Observes
+                              ContainerResourcePolicy. This amount is not guaranteed
+                              to be sufficient for the application to operate in a stable
+                              way, however running with less resources is likely to
+                              have significant impact on performance/availability.
+                            type: object
+                          target:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: Recommended amount of resources. Observes ContainerResourcePolicy.
+                            type: object
+                          uncappedTarget:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description:
+                              The most recent recommended resources target
+                              computed by the autoscaler for the controlled pods, based
+                              only on actual resource usage, not taking into account
+                              the ContainerResourcePolicy. May differ from the Recommendation
+                              if the actual resource usage causes the target to violate
+                              the ContainerResourcePolicy (lower than MinAllowed or
+                              higher that MaxAllowed). Used only as status indication,
+                              will not affect actual resource assignment.
+                            type: object
+                          upperBound:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description:
+                              Maximum recommended amount of resources. Observes
+                              ContainerResourcePolicy. Any resources allocated beyond
+                              this value are likely wasted. This value may be larger
+                              than the maximum amount of application is actually capable
+                              of consuming.
+                            type: object
+                        required:
+                          - target
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
       served: true
       storage: true
-    - name: v1
+    - name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description:
+            VerticalPodAutoscaler is the configuration for a vertical pod
+            autoscaler, which automatically manages pod resources based on historical
+            and real time resource utilization.
+          properties:
+            apiVersion:
+              description:
+                "APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description:
+                "Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                "Specification of the behavior of the autoscaler. More info:
+                https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status."
+              properties:
+                resourcePolicy:
+                  description:
+                    Controls how the autoscaler computes recommended resources.
+                    The resource policy may be used to set constraints on the recommendations
+                    for individual containers. If not specified, the autoscaler computes
+                    recommended resources for all containers in the pod, without additional
+                    constraints.
+                  properties:
+                    containerPolicies:
+                      description: Per-container resource policies.
+                      items:
+                        description:
+                          ContainerResourcePolicy controls how autoscaler
+                          computes the recommended resources for a specific container.
+                        properties:
+                          containerName:
+                            description:
+                              Name of the container or DefaultContainerResourcePolicy,
+                              in which case the policy is used by the containers that
+                              don't have their own policy specified.
+                            type: string
+                          maxAllowed:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description:
+                              Specifies the maximum amount of resources that
+                              will be recommended for the container. The default is
+                              no maximum.
+                            type: object
+                          minAllowed:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description:
+                              Specifies the minimal amount of resources that
+                              will be recommended for the container. The default is
+                              no minimum.
+                            type: object
+                          mode:
+                            description:
+                              Whether autoscaler is enabled for the container.
+                              The default is "Auto".
+                            enum:
+                              - Auto
+                              - "Off"
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                targetRef:
+                  description:
+                    TargetRef points to the controller managing the set of
+                    pods for the autoscaler to control - e.g. Deployment, StatefulSet.
+                    VerticalPodAutoscaler can be targeted at controller implementing
+                    scale subresource (the pod set is retrieved from the controller's
+                    ScaleStatus) or some well known controllers (e.g. for DaemonSet
+                    the pod set is read from the controller's spec). If VerticalPodAutoscaler
+                    cannot use specified target it will report ConfigUnsupported condition.
+                    Note that VerticalPodAutoscaler does not require full implementation
+                    of scale subresource - it will not use it to modify the replica
+                    count. The only thing retrieved is a label selector matching pods
+                    grouped by the target resource.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent
+                      type: string
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                      type: string
+                    name:
+                      description: "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+                      type: string
+                  required:
+                    - kind
+                    - name
+                  type: object
+                updatePolicy:
+                  description:
+                    Describes the rules on how changes are applied to the
+                    pods. If not specified, all fields in the `PodUpdatePolicy` are
+                    set to their default values.
+                  properties:
+                    updateMode:
+                      description:
+                        Controls when autoscaler applies changes to the pod
+                        resources. The default is 'Auto'.
+                      enum:
+                        - "Off"
+                        - Initial
+                        - Recreate
+                        - Auto
+                      type: string
+                  type: object
+              required:
+                - targetRef
+              type: object
+            status:
+              description: Current information about the autoscaler.
+              properties:
+                conditions:
+                  description:
+                    Conditions is the set of conditions required for this
+                    autoscaler to scale its target, and indicates whether or not those
+                    conditions are met.
+                  items:
+                    description:
+                      VerticalPodAutoscalerCondition describes the state
+                      of a VerticalPodAutoscaler at a certain point.
+                    properties:
+                      lastTransitionTime:
+                        description:
+                          lastTransitionTime is the last time the condition
+                          transitioned from one status to another
+                        format: date-time
+                        type: string
+                      message:
+                        description:
+                          message is a human-readable explanation containing
+                          details about the transition
+                        type: string
+                      reason:
+                        description: reason is the reason for the condition's last transition.
+                        type: string
+                      status:
+                        description:
+                          status is the status of the condition (True, False,
+                          Unknown)
+                        type: string
+                      type:
+                        description: type describes the current condition
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                recommendation:
+                  description:
+                    The most recently computed amount of resources recommended
+                    by the autoscaler for the controlled pods.
+                  properties:
+                    containerRecommendations:
+                      description:
+                        Resources recommended by the autoscaler for each
+                        container.
+                      items:
+                        description:
+                          RecommendedContainerResources is the recommendation
+                          of resources computed by autoscaler for a specific container.
+                          Respects the container resource policy if present in the spec.
+                          In particular the recommendation is not produced for containers
+                          with `ContainerScalingMode` set to 'Off'.
+                        properties:
+                          containerName:
+                            description: Name of the container.
+                            type: string
+                          lowerBound:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description:
+                              Minimum recommended amount of resources. Observes
+                              ContainerResourcePolicy. This amount is not guaranteed
+                              to be sufficient for the application to operate in a stable
+                              way, however running with less resources is likely to
+                              have significant impact on performance/availability.
+                            type: object
+                          target:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: Recommended amount of resources. Observes ContainerResourcePolicy.
+                            type: object
+                          uncappedTarget:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description:
+                              The most recent recommended resources target
+                              computed by the autoscaler for the controlled pods, based
+                              only on actual resource usage, not taking into account
+                              the ContainerResourcePolicy. May differ from the Recommendation
+                              if the actual resource usage causes the target to violate
+                              the ContainerResourcePolicy (lower than MinAllowed or
+                              higher that MaxAllowed). Used only as status indication,
+                              will not affect actual resource assignment.
+                            type: object
+                          upperBound:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description:
+                              Maximum recommended amount of resources. Observes
+                              ContainerResourcePolicy. Any resources allocated beyond
+                              this value are likely wasted. This value may be larger
+                              than the maximum amount of application is actually capable
+                              of consuming.
+                            type: object
+                        required:
+                          - target
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
       served: true
       storage: false
-  validation:
-    # openAPIV3Schema is the schema for validating custom objects.
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          properties:
-            targetRef:
-              type: object
-            updatePolicy:
-              type: object
-              properties:
-                updateMode:
-                  type: string
-            resourcePolicy:
-              type: object
-              properties:
-                containerPolicies:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      containerName:
-                        type: string
-                      controlledValues:
-                        type: string
-                        enum: ["RequestsAndLimits", "RequestsOnly"]
-                      mode:
-                        type: string
-                        enum: ["Auto", "Off"]
-                      minAllowed:
-                        type: object
-                      maxAllowed:
-                        type: object
-                      controlledResources:
-                        type: array
-                        items:
-                          type: string
-                          enum: ["cpu", "memory"]
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
   annotations:
-    "api-approved.kubernetes.io": "https://github.com/kubernetes/kubernetes/pull/63797"
+    api-approved.kubernetes.io: https://github.com/kubernetes/kubernetes/pull/63797
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
 spec:
   group: autoscaling.k8s.io
-  scope: Namespaced
   names:
-    plural: verticalpodautoscalercheckpoints
-    singular: verticalpodautoscalercheckpoint
     kind: VerticalPodAutoscalerCheckpoint
+    listKind: VerticalPodAutoscalerCheckpointList
+    plural: verticalpodautoscalercheckpoints
     shortNames:
       - vpacheckpoint
-  version: v1beta1
+    singular: verticalpodautoscalercheckpoint
+  scope: Namespaced
   versions:
-    - name: v1beta1
-      served: false
-      storage: false
-    - name: v1beta2
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description:
+            VerticalPodAutoscalerCheckpoint is the checkpoint of the internal
+            state of VPA that is used for recovery after recommender's restart.
+          properties:
+            apiVersion:
+              description:
+                "APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description:
+                "Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: "Specification of the checkpoint. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status."
+              properties:
+                containerName:
+                  description: Name of the checkpointed container.
+                  type: string
+                vpaObjectName:
+                  description:
+                    Name of the VPA object that stored VerticalPodAutoscalerCheckpoint
+                    object.
+                  type: string
+              type: object
+            status:
+              description: Data of the checkpoint.
+              properties:
+                cpuHistogram:
+                  description: Checkpoint of histogram for consumption of CPU.
+                  properties:
+                    bucketWeights:
+                      description: Map from bucket index to bucket weight.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    referenceTimestamp:
+                      description:
+                        Reference timestamp for samples collected within
+                        this histogram.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    totalWeight:
+                      description:
+                        Sum of samples to be used as denominator for weights
+                        from BucketWeights.
+                      type: number
+                  type: object
+                firstSampleStart:
+                  description: Timestamp of the fist sample from the histograms.
+                  format: date-time
+                  nullable: true
+                  type: string
+                lastSampleStart:
+                  description: Timestamp of the last sample from the histograms.
+                  format: date-time
+                  nullable: true
+                  type: string
+                lastUpdateTime:
+                  description: The time when the status was last refreshed.
+                  format: date-time
+                  nullable: true
+                  type: string
+                memoryHistogram:
+                  description: Checkpoint of histogram for consumption of memory.
+                  properties:
+                    bucketWeights:
+                      description: Map from bucket index to bucket weight.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    referenceTimestamp:
+                      description:
+                        Reference timestamp for samples collected within
+                        this histogram.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    totalWeight:
+                      description:
+                        Sum of samples to be used as denominator for weights
+                        from BucketWeights.
+                      type: number
+                  type: object
+                totalSamplesCount:
+                  description: Total number of samples in the histograms.
+                  type: integer
+                version:
+                  description: Version of the format of the stored data.
+                  type: string
+              type: object
+          type: object
       served: true
       storage: true
-    - name: v1
+    - name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description:
+            VerticalPodAutoscalerCheckpoint is the checkpoint of the internal
+            state of VPA that is used for recovery after recommender's restart.
+          properties:
+            apiVersion:
+              description:
+                "APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description:
+                "Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: "Specification of the checkpoint. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status."
+              properties:
+                containerName:
+                  description: Name of the checkpointed container.
+                  type: string
+                vpaObjectName:
+                  description:
+                    Name of the VPA object that stored VerticalPodAutoscalerCheckpoint
+                    object.
+                  type: string
+              type: object
+            status:
+              description: Data of the checkpoint.
+              properties:
+                cpuHistogram:
+                  description: Checkpoint of histogram for consumption of CPU.
+                  properties:
+                    bucketWeights:
+                      description: Map from bucket index to bucket weight.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    referenceTimestamp:
+                      description:
+                        Reference timestamp for samples collected within
+                        this histogram.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    totalWeight:
+                      description:
+                        Sum of samples to be used as denominator for weights
+                        from BucketWeights.
+                      type: number
+                  type: object
+                firstSampleStart:
+                  description: Timestamp of the fist sample from the histograms.
+                  format: date-time
+                  nullable: true
+                  type: string
+                lastSampleStart:
+                  description: Timestamp of the last sample from the histograms.
+                  format: date-time
+                  nullable: true
+                  type: string
+                lastUpdateTime:
+                  description: The time when the status was last refreshed.
+                  format: date-time
+                  nullable: true
+                  type: string
+                memoryHistogram:
+                  description: Checkpoint of histogram for consumption of memory.
+                  properties:
+                    bucketWeights:
+                      description: Map from bucket index to bucket weight.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    referenceTimestamp:
+                      description:
+                        Reference timestamp for samples collected within
+                        this histogram.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    totalWeight:
+                      description:
+                        Sum of samples to be used as denominator for weights
+                        from BucketWeights.
+                      type: number
+                  type: object
+                totalSamplesCount:
+                  description: Total number of samples in the histograms.
+                  type: integer
+                version:
+                  description: Version of the format of the stored data.
+                  type: string
+              type: object
+          type: object
       served: true
       storage: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
**Why This PR?**
Be able to use this helm chart in Kubernetes greater or equal to v1.22

Fixes #580 

**Changes**
Changes proposed in this pull request:

* Update CRD based on the upstream CRD (https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml) to get supported apiversion on the CRD
* Bump minor version

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
