### PR TITLE
[goldilocks] Update VPA subchart version

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v3.1.4"
-version: 3.2.8
+version: 3.3.0
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks
@@ -16,7 +16,7 @@ keywords:
   - kubernetes
 dependencies:
 - name: vpa
-  version: 0.4.3
+  version: 0.5.0
   repository: https://charts.fairwinds.com/stable
   condition: vpa.enabled
 - name: metrics-server


### PR DESCRIPTION
**Why This PR?**
The VPA chart was recently updated to use the stable apiVersion of CRD,
so we should reference that new chart version.

Fixes #
Avoid the future deprecation of CRD apiVersion

**Changes**
Changes proposed in this pull request:

* VPA version reference bumped up in Goldilocks (subchart)

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.