### PR TITLE
[goldilocks] don't install VPA updater

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v3.1.4"
-version: 3.3.0
+version: 3.3.1
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -47,6 +47,7 @@ This will completely remove the VPA and then re-install it using the new method.
 |-----|------|---------|-------------|
 | uninstallVPA | bool | `false` | Enabling this flag will remove a vpa installation that was previously managed with this chart. It is considered deprecated and will be removed in a later release. |
 | vpa.enabled | bool | `false` | If true, the vpa will be installed as a sub-chart |
+| vpa.updater.enabled | bool | `false` |  |
 | metrics-server.enabled | bool | `false` | If true, the metrics-server will be installed as a sub-chart |
 | metrics-server.apiService.create | bool | `true` |  |
 | image.repository | string | `"quay.io/fairwinds/goldilocks"` | Repository for the goldilocks image |

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -4,6 +4,8 @@ uninstallVPA: false
 vpa:
   # vpa.enabled -- If true, the vpa will be installed as a sub-chart
   enabled: false
+  updater:
+    enabled: false
 
 metrics-server:
   # metrics-server.enabled -- If true, the metrics-server will be installed as a sub-chart


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_
Goldilocks doesn't need the VPA updater

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.
