### PR TITLE
[goldilocks] update to v4.0.0

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: "v3.1.4"
-version: 3.3.1
+appVersion: "v4.0.0"
+version: 4.0.0
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -55,7 +55,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | metrics-server.enabled | bool | `false` | If true, the metrics-server will be installed as a sub-chart |
 | metrics-server.apiService.create | bool | `true` |  |
 | image.repository | string | `"quay.io/fairwinds/goldilocks"` | Repository for the goldilocks image |
-| image.tag | string | `"v3.1.4"` | The goldilocks image tag to use |
+| image.tag | string | `"v4.0.0"` | The goldilocks image tag to use |
 | image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as `Always` |
 | nameOverride | string | `""` |  |
 | fullnameOverride | string | `""` |  |

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -25,7 +25,7 @@ Fairwinds has published a chart for installing VPA [in our stable repo](https://
 
 ## Upgrading from v3.x.x to v4.x.x
 
-There are not breaking changes, but the goldilocks controller and dashboard have had some major tweaks so they can work with more workload controllers. To allow v4.0.0+ to work with more than Deployments, the main change here is in RBAC permissions so that the goldilocks service accounts can access all resources in the `apps/v1`.
+There are no breaking changes, but the goldilocks controller and dashboard have had some major tweaks so they can work with more workload controllers. To allow v4.0.0+ to work with more than Deployments, the main change here is in RBAC permissions so that the goldilocks service accounts can access all resources in the `apps/v1`.
 
 ## *BREAKING* Upgrading from v2.x.x to v3.x.x
 

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -23,6 +23,10 @@ Fairwinds has published a chart for installing VPA [in our stable repo](https://
 
 ## Major Version Upgrade Notes
 
+## Upgrading from v3.x.x to v4.x.x
+
+There are not breaking changes, but the goldilocks controller and dashboard have had some major tweaks so they can work with more workload controllers. To allow v4.0.0+ to work with more than Deployments, the main change here is in RBAC permissions so that the goldilocks service accounts can access all resources in the `apps/v1`.
+
 ## *BREAKING* Upgrading from v2.x.x to v3.x.x
 
 In this change, the `installVPA` value and corresponding hooks have been removed in favor of the sub-chart. The recommended path forward is to remove the hook-installed resources and manage the VPA installation with the [Fairwinds VPA Chart](https://github.com/FairwindsOps/charts/tree/master/stable/vpa)

--- a/stable/goldilocks/README.md.gotmpl
+++ b/stable/goldilocks/README.md.gotmpl
@@ -25,7 +25,7 @@ Fairwinds has published a chart for installing VPA [in our stable repo](https://
 
 ## Upgrading from v3.x.x to v4.x.x
 
-There are not breaking changes, but the goldilocks controller and dashboard have had some major tweaks so they can work with more workload controllers. To allow v4.0.0+ to work with more than Deployments, the main change here is in RBAC permissions so that the goldilocks service accounts can access all resources in the `apps/v1`.
+There are no breaking changes, but the goldilocks controller and dashboard have had some major tweaks so they can work with more workload controllers. To allow v4.0.0+ to work with more than Deployments, the main change here is in RBAC permissions so that the goldilocks service accounts can access all resources in the `apps/v1`.
 
 ## *BREAKING* Upgrading from v2.x.x to v3.x.x
 

--- a/stable/goldilocks/README.md.gotmpl
+++ b/stable/goldilocks/README.md.gotmpl
@@ -23,6 +23,10 @@ Fairwinds has published a chart for installing VPA [in our stable repo](https://
 
 ## Major Version Upgrade Notes
 
+## Upgrading from v3.x.x to v4.x.x
+
+There are not breaking changes, but the goldilocks controller and dashboard have had some major tweaks so they can work with more workload controllers. To allow v4.0.0+ to work with more than Deployments, the main change here is in RBAC permissions so that the goldilocks service accounts can access all resources in the `apps/v1`.
+
 ## *BREAKING* Upgrading from v2.x.x to v3.x.x
 
 In this change, the `installVPA` value and corresponding hooks have been removed in favor of the sub-chart. The recommended path forward is to remove the hook-installed resources and manage the VPA installation with the [Fairwinds VPA Chart](https://github.com/FairwindsOps/charts/tree/master/stable/vpa)

--- a/stable/goldilocks/templates/controller-clusterrole.yaml
+++ b/stable/goldilocks/templates/controller-clusterrole.yaml
@@ -13,7 +13,7 @@ rules:
   - apiGroups:
       - 'apps'
     resources:
-      - 'deployments'
+      - '*'
     verbs:
       - 'get'
       - 'list'

--- a/stable/goldilocks/templates/dashboard-clusterrole.yaml
+++ b/stable/goldilocks/templates/dashboard-clusterrole.yaml
@@ -20,7 +20,7 @@ rules:
   - apiGroups:
       - 'apps'
     resources:
-      - 'deployments'
+      - '*'
     verbs:
       - 'get'
       - 'list'
@@ -28,6 +28,7 @@ rules:
       - ''
     resources:
       - 'namespaces'
+      - 'pods'
     verbs:
       - 'get'
       - 'list'

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -17,7 +17,7 @@ image:
   # image.repository -- Repository for the goldilocks image
   repository: quay.io/fairwinds/goldilocks
   # image.tag -- The goldilocks image tag to use
-  tag: v3.1.4
+  tag: v4.0.0
   # image.pullPolicy -- imagePullPolicy - Highly recommended to leave this as `Always`
   pullPolicy: Always
 


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Support the latest version of goldilocks.

Fixes #

**Changes**
Changes proposed in this pull request:

* Update app and chart version to 4.0.0
* Adjust RBAC permissions to allow the serviceaccounts read-only access
  to all resources under the `apps/v1` apiGroup.

**Checklist:**

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or helm-docs has been run for the charts that support it.