### PR TITLE
[stable/insights-agent]: Add `trivy.env` to pass environment variables to the trivy container

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.8.4
+## 2.9.1
 * Add a `trivy.env` chart value to allow passing environment variables to the trivy container, as a map of `name: value`.
 
 ## 2.8.3

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.8.4
+* Add a `trivy.env` chart value to allow passing environment variables to the trivy container, as a map of `name: value`.
+
 ## 2.8.3
 * Update pluto to 5.11
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.8.3
+version: 2.8.4
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.8.4
+version: 2.9.1
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -104,6 +104,7 @@ Parameter | Description | Default
 `trivy.maxScansPerRun` | Maximum number of images to scan on a single run | 20
 `trivy.namespaceBlacklist` | Specifies which namespaces to not scan, takes an array of namespaces for example: `--set trivy.namespaceBlacklist="{kube-system,default}"` | nil
 `trivy.serviceAccount.annotations` | Annotations to add to the Trivy service account, e.g. `eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME` for accessing private images | nil
+`trivy.env` | A map of environment variables that will be set for the trivy container. | `nil`
 `opa.role` | Specifies which ClusterRole to grant the OPA agent access to | view
 `opa.additionalAccess` | Specifies additional access to grant the OPA agent. This should contain an array of objects with each having an array of apiGroups, an array of resources, and an array of verbs. Just like a RoleBinding. | null
 `insights-agent` chart twice you will want to set this flag to `false` on *one* of the installs, doesn't matter which. | true

--- a/stable/insights-agent/templates/trivy/cronjob.yaml
+++ b/stable/insights-agent/templates/trivy/cronjob.yaml
@@ -34,6 +34,10 @@ spec:
               - "./report.sh"
             env:
             {{ include "proxy-env-spec" . | indent 12 | trim }}
+            {{- range $key, $value := .Values.trivy.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
             - name: FAIRWINDS_INSIGHTS_HOST
               value: {{ .Values.insights.host | quote }}
             - name: FAIRWINDS_ORG

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -254,6 +254,8 @@ trivy:
   maxScansPerRun: 20
   timeout: 2400
   insecureSSL: false
+  # trivy.env -- A map of environment variables that will be set for the trivy container.
+  env:
   image:
     repository: quay.io/fairwinds/fw-trivy
     tag: "0.22"


### PR DESCRIPTION
**Why This PR?**
Facilitate passing environment variables to the Trivy container, using a new `Trivy.env` chart value. This is to help work around [Trivy not authenticating with ECR when ECR is in a different region](https://github.com/aquasecurity/trivy/issues/1026).

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
