### PR TITLE
[insights-agent] Use stable-main as the backend for fleet installer test

### DIFF
--- a/scripts/fleet-install-test.sh
+++ b/scripts/fleet-install-test.sh
@@ -12,9 +12,9 @@ case "$CHANGED" in
   *insights-agent*)
     printf "The changed charts include insights-agent. Running fleet install test\n"
 
-    # We use the be-main server to do the test. This is not ideal but will suffice for now
+    # We use the stable-main server to do the test. This is a server that gets deployed once every night
     # Here we check to make sure that the server is up
-    URL="https://be-main.k8s.insights.fairwinds.com" 
+    URL="https://stable-main.k8s.insights.fairwinds.com" 
     retry=0
     while ! curl -k --no-progress-meter $URL; do
       printf "Server is not up yet. Waiting for it to start...\n";

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.11.1
+* Changed the backend for the fleet installer test
+
 ## 2.11.0
 * Bumped AWS costs plugin for new Days parameter
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.11.0
+version: 2.11.1
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/ci/fleet-install-test.yaml
+++ b/stable/insights-agent/ci/fleet-install-test.yaml
@@ -1,6 +1,6 @@
 fleetInstall: true
 insights:
-  host: https://be-main.k8s.insights.fairwinds.com
+  host: https://stable-main.k8s.insights.fairwinds.com
   organization: acme-co
   tokenSecretName: insights-token
   apiToken: thisisanadmintoken


### PR DESCRIPTION
**Why This PR?**
Use stable-main as the backend for fleet installer test

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
