### PR TITLE
[stable/insights-agent] Fix kube-bench duplicate volumes on if statement

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.17.3
+* Move duplicate volumes statement in kube-bench inside the if statement
+
 ## 2.17.2
 * Fix issue with kube-bench volumes
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.17.2
+version: 2.17.3
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/templates/kube-bench/cronjob.yaml
+++ b/stable/insights-agent/templates/kube-bench/cronjob.yaml
@@ -17,9 +17,9 @@ spec:
         {{ include "job-spec-metadata" . | nindent 8 | trim }}
         spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
+          {{- if or (eq (index .Values "kube-bench" "mode") "daemonsetMaster") (eq (index .Values "kube-bench" "mode") "daemonset") }}
           volumes:
           {{ include "ssl-cert-file-volume-spec" . | indent 10 }}
-          {{- if or (eq (index .Values "kube-bench" "mode") "daemonsetMaster") (eq (index .Values "kube-bench" "mode") "daemonset") }}
           - name: output
             emptyDir: {}
           containers:


### PR DESCRIPTION
**Why This PR?**
The `volumes` definition to contain the ssl-cert-file-volume-spec was outside the if statement, so if we used the _container template, we got multiple `volumes` keys


Fixes #

**Changes**
Changes proposed in this pull request:

* Move the offending statement inside the `if` statement

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.