### PR TITLE
FWI-4570 - Add Kyverno plugin to [stable/insights-agent]

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.22.0
+* Add Kyverno plugin
+
 ## 2.21.6
 * Update Polaris to 8.4
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 2.21.6
+version: 2.22.0
 appVersion: 9.2.1
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
 maintainers:

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -131,6 +131,12 @@ falco:
     requests:
       cpu: 50m
 
+kyverno:
+  enabled: true
+  resources:
+    requests:
+      cpu: 50m
+
 installReporter:
   additionalAnnotations:
     "argocd.argoproj.io/hook": PostSync

--- a/stable/insights-agent/templates/kyverno/cronjob.yaml
+++ b/stable/insights-agent/templates/kyverno/cronjob.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.kyverno .Values.kyverno.enabled -}}
+{{- $_ := set . "Label" "kyverno" }}
+{{- $_ := set . "Config" .Values.kyverno }}
+{{- include "cronjob" . }}
+spec:
+  {{ include "cronjob-spec" . | nindent 2 | trim }}
+  jobTemplate:
+    spec:
+      {{ include "job-spec" . | nindent 6 | trim }}
+      template:
+        {{ include "job-spec-metadata" . | nindent 8 | trim }}
+        spec:
+          {{ include "job-template-spec" . | indent 10 | trim }}
+          containers:
+          - {{ include "container-spec" . | indent 12 | trim }}
+            env:
+            - name: FAIRWINDS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  {{ if .Values.insights.tokenSecretName -}}
+                  name: {{ .Values.insights.tokenSecretName }}
+                  {{ else -}}
+                  name: {{ include "insights-agent.fullname" . }}-token
+                  {{ end -}}
+                  key: token
+            - name: FAIRWINDS_INSIGHTS_HOST
+              value: {{ .Values.insights.host }}
+            - name: FAIRWINDS_ORG
+              value: {{ .Values.insights.organization | quote  }}
+            - name: FAIRWINDS_CLUSTER
+              value: {{ .Values.insights.cluster | quote }}
+            {{ include "proxy-env-spec" . | indent 12 | trim }}
+{{ include "ssl-cert-file-env-spec" . | indent 12 }}
+            {{ include "security-context" . | indent 12 | trim }}
+          {{ include "uploaderContainer" . | indent 10 | trim }}
+{{- end -}}

--- a/stable/insights-agent/templates/kyverno/cronjob.yaml
+++ b/stable/insights-agent/templates/kyverno/cronjob.yaml
@@ -13,24 +13,7 @@ spec:
           {{ include "job-template-spec" . | indent 10 | trim }}
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
-            env:
-            - name: FAIRWINDS_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  {{ if .Values.insights.tokenSecretName -}}
-                  name: {{ .Values.insights.tokenSecretName }}
-                  {{ else -}}
-                  name: {{ include "insights-agent.fullname" . }}-token
-                  {{ end -}}
-                  key: token
-            - name: FAIRWINDS_INSIGHTS_HOST
-              value: {{ .Values.insights.host }}
-            - name: FAIRWINDS_ORG
-              value: {{ .Values.insights.organization | quote  }}
-            - name: FAIRWINDS_CLUSTER
-              value: {{ .Values.insights.cluster | quote }}
             {{ include "proxy-env-spec" . | indent 12 | trim }}
-{{ include "ssl-cert-file-env-spec" . | indent 12 }}
             {{ include "security-context" . | indent 12 | trim }}
           {{ include "uploaderContainer" . | indent 10 | trim }}
 {{- end -}}

--- a/stable/insights-agent/templates/kyverno/rbac.yaml
+++ b/stable/insights-agent/templates/kyverno/rbac.yaml
@@ -16,6 +16,8 @@ rules:
 - apiGroups:
   - '*'
   resources:
+  - customresourcedefinitions
+  - namespaces
   - policyreports
   - policyreports/status
   - clusterpolicyreports

--- a/stable/insights-agent/templates/kyverno/rbac.yaml
+++ b/stable/insights-agent/templates/kyverno/rbac.yaml
@@ -1,0 +1,42 @@
+{{- if and (and .Values.kyverno .Values.kyverno.enabled) (not .Values.rbac.disabled) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "insights-agent.fullname" . }}-kyverno
+  labels:
+    app: insights-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "insights-agent.fullname" $ }}-kyverno
+  labels:
+    app: insights-agent
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - policyreports
+  - policyreports/status
+  - clusterpolicyreports
+  - clusterpolicyreports/status
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "insights-agent.fullname" $ }}-kyverno
+  labels:
+    app: insights-agent
+roleRef:
+  kind: ClusterRole
+  name: {{ include "insights-agent.fullname" $ }}-kyverno
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: {{ include "insights-agent.fullname" . }}-kyverno
+  namespace: {{ $.Release.Namespace }}
+{{- end }}

--- a/stable/insights-agent/templates/rbac.yaml
+++ b/stable/insights-agent/templates/rbac.yaml
@@ -43,6 +43,11 @@ subjects:
   name: {{ include "insights-agent.fullname" . }}-opa
   namespace: {{ .Release.Namespace }}
 {{- end }}
+{{- if .Values.kyverno.enabled }}
+- kind: ServiceAccount
+  name: {{ include "insights-agent.fullname" . }}-kyverno
+  namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- if .Values.prometheus.enabled }}
 - kind: ServiceAccount
   name: {{ include "insights-agent.fullname" . }}-prometheus

--- a/stable/insights-agent/templates/rbac.yaml
+++ b/stable/insights-agent/templates/rbac.yaml
@@ -43,7 +43,7 @@ subjects:
   name: {{ include "insights-agent.fullname" . }}-opa
   namespace: {{ .Release.Namespace }}
 {{- end }}
-{{- if .Values.kyverno.enabled }}
+{{- if and .Values.kyverno .Values.kyverno.enabled }}
 - kind: ServiceAccount
   name: {{ include "insights-agent.fullname" . }}-kyverno
   namespace: {{ .Release.Namespace }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -577,7 +577,7 @@ falcosecurity:
         checkcert: true
 
 kyverno:
-  enabled: true
+  enabled: false
   schedule: "rand * * * *"
   image:
     repository: quay.io/fairwinds/kyverno

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -581,8 +581,9 @@ kyverno:
   schedule: "rand * * * *"
   image:
     repository: quay.io/fairwinds/kyverno
-    tag: "0.1"
+    tag: "0.1.1"
   resources:
     requests:
       cpu: 100m
       memory: 128Mi
+  timeout: 300

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -29,7 +29,7 @@ rbac:
 uploader:
   image:
     repository: quay.io/fairwinds/insights-uploader
-    tag: "0.5"
+    tag: "0.5.1"
   imagePullSecret: ""
   sendFailures: true
   resources:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -581,7 +581,7 @@ kyverno:
   schedule: "rand * * * *"
   image:
     repository: quay.io/fairwinds/kyverno
-    tag: "0.1.1"
+    tag: "0.1"
   resources:
     requests:
       cpu: 100m

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -575,3 +575,14 @@ falcosecurity:
         minimumpriority: ""
         mutualtls: false
         checkcert: true
+
+kyverno:
+  enabled: true
+  schedule: "rand * * * *"
+  image:
+    repository: quay.io/fairwinds/kyverno
+    tag: "0.1"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi


### PR DESCRIPTION
**Why This PR?**
This introduces helm configuration for the `kyverno` insights plugin

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
