### PR TITLE
allow pod annotations for job

### DIFF
--- a/stable/vpa/templates/webhooks/jobs/certgen-patch.yaml
+++ b/stable/vpa/templates/webhooks/jobs/certgen-patch.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app.kubernetes.io/component: admission-certgen
         {{- include "vpa.labels" . | nindent 8 }}
+      {{- with .Values.admissionController.certGen.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ include "vpa.fullname" . }}-admission-certgen

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -219,6 +219,8 @@ admissionController:
       pullPolicy: Always
     # admissionController.certGen.env -- Additional environment variables to be added to the certgen container. Format is KEY: Value format
     env: {}
+    # admissionController.certGen.podAnnotations -- Annotations to add to the certgen pod
+    podAnnotations: {}
     # admissionController.certGen.resources -- The resources block for the certgen pod
     resources: {}
     # admissionController.certGen.podSecurityContext -- The securityContext block for the certgen pod(s)


### PR DESCRIPTION
**Why This PR?**
Allow pod annotations

Fixes #

Allows users to add custom pod annotations to the pods that is created via the job ; example disable istio

*
*

**Checklist:**

* [ ] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/vpa]`.
* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
