### PR TITLE
[stable/insights-agent] - Add annotations for liveness and readiness probs exemptions

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.7.1
+* fix `on-demand-job-runner` templating and default values
+
 ## 4.7.0
 * add `on-demand-job-runner` workload
 * fix falco.tolerations typo

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 4.7.0
+version: 4.7.1
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/on-demand-job-runner/deployment.yaml
+++ b/stable/insights-agent/templates/on-demand-job-runner/deployment.yaml
@@ -13,10 +13,10 @@ spec:
     metadata:
       labels:
         app: {{ .Label }}
-    {{- if .Values.onDemandJobRunner.podAnnotations }}
+      {{- with .Values.onDemandJobRunner.podAnnotations }}
       annotations:
-        {{ toYaml .Values.onDemandJobRunner.podAnnotations | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "insights-agent.fullname" . }}-{{ .Label }}-sa
       securityContext:
@@ -26,8 +26,8 @@ spec:
     {{- end }}
     {{- with .Values.onDemandJobRunner.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 6 }}
-     {{- end }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
       - name: {{ .Label }}
         env:
@@ -51,24 +51,24 @@ spec:
               name: {{ include "insights-agent.fullname" . }}-token
               {{ end -}}
               key: token
-      {{- if .Values.onDemandJobRunner.containerSecurityContext }}
+        {{- with .Values.onDemandJobRunner.containerSecurityContext }}
         securityContext:
-          {{- toYaml .Values.onDemandJobRunner.containerSecurityContext | nindent 12 }}
-      {{- end }}
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
         imagePullPolicy: {{ .Values.onDemandJobRunner.image.pullPolicy }}
         image: "{{ .Values.onDemandJobRunner.image.repository }}:{{ .Values.onDemandJobRunner.image.tag }}"
         resources:
         {{- toYaml .Values.onDemandJobRunner.resources | nindent 10 }}
     {{- with .Values.onDemandJobRunner.affinity }}
       affinity:
-        {{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.onDemandJobRunner.nodeSelector }}
       nodeSelector:
-        {{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.onDemandJobRunner.tolerations }}
       tolerations:
-        {{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
 {{- end -}}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -718,6 +718,9 @@ onDemandJobRunner:
     capabilities:
       drop:
         - ALL
+  annotations:
+    polaris.fairwinds.com/livenessProbeMissing-exempt: "true"
+    polaris.fairwinds.com/readinessProbeMissing-exempt: "true"
   tolerations: []
   resources:
     limits:


### PR DESCRIPTION
[ondemandjobrunner] Add annotations for liveness and readiness probs exemptions

**Why This PR?**
* add default Polaris exemptions
* fix templating

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
