### PR TITLE
[stable/fairwinds-insights] Update insights liveness and readiness probes

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.3
+* Update Fairwinds Insights API deployment liveness and readiness probes
+
 ## 3.1.2
 * Update application version to 17.0. [See the release notes for more details](https://insights.docs.fairwinds.com/release-notes)
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "17.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 3.1.2
+version: 3.1.3
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "16.4"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 3.1.0
+version: 3.1.1
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/templates/deployment-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-api.yaml
@@ -41,14 +41,14 @@ spec:
           {{- include "env" (dict "root" .) | indent 10 }}
           livenessProbe:
             httpGet:
-              path: /health
+              path: /livez
               port: http
             timeoutSeconds: 5
             periodSeconds: 5
             failureThreshold: 12
           readinessProbe:
             httpGet:
-              path: /health
+              path: /readyz
               port: http
             timeoutSeconds: 5
             periodSeconds: 5


### PR DESCRIPTION
**Why This PR?**
Update insights liveness and readiness probes

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
