### PR TITLE
[stable/fairwinds-insights] bump Temporal chart and use default log level

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.7
+* Bump Temporal chart to latest and use default log level
+
 ## 3.1.6
 * Add default temporal namespace for fwinsights
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "17.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 3.1.6
+version: 3.1.7
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren
@@ -23,7 +23,7 @@ dependencies:
     condition: timescale.ephemeral
     alias: timescale
   - name: temporal
-    version: 0.63.0
+    version: 0.65.0
     repository: https://go.temporal.io/helm-charts
     condition: temporal.enabled
     alias: temporal

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -307,7 +307,6 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | temporal.mysql.enabled | bool | `false` |  |
 | temporal.postgresql.enabled | bool | `true` |  |
 | temporal.server.replicaCount | int | `1` |  |
-| temporal.server.config.logLevel | string | `"debug"` |  |
 | temporal.server.config.namespaces.create | bool | `true` |  |
 | temporal.server.config.namespaces.namespace[0].name | string | `"fwinsights"` |  |
 | temporal.server.config.namespaces.namespace[0].retention | string | `"3d"` |  |

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -805,7 +805,6 @@ temporal:
   server:
     replicaCount: 1
     config:
-      logLevel: "debug"
       namespaces:
         create: true
         namespace:


### PR DESCRIPTION
**Why This PR?**
- Bump Temporal chart and use default log level

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
