### PR TITLE
[stable/fairwinds-insights] Lower temporal defauls conn

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.8
+* Lower Temporal max and maxIdle default connections
+
 ## 3.1.7
 * Bump Temporal chart to latest and use default log level
 

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.7
+* Bump Temporal chart to latest and use default log level
+
 ## 3.1.6
 * Add default temporal namespace for fwinsights
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "17.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 3.1.7
+version: 3.1.8
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "17.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 3.1.6
+version: 3.1.7
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren
@@ -23,7 +23,7 @@ dependencies:
     condition: timescale.ephemeral
     alias: timescale
   - name: temporal
-    version: 0.63.0
+    version: 0.65.0
     repository: https://go.temporal.io/helm-charts
     condition: temporal.enabled
     alias: temporal

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -317,8 +317,8 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | temporal.server.config.persistence.default.sql.port | int | `5432` |  |
 | temporal.server.config.persistence.default.sql.user | string | `"postgres"` |  |
 | temporal.server.config.persistence.default.sql.existingSecret | string | `"fwinsights-postgresql"` |  |
-| temporal.server.config.persistence.default.sql.maxConns | int | `20` |  |
-| temporal.server.config.persistence.default.sql.maxIdleConns | int | `20` |  |
+| temporal.server.config.persistence.default.sql.maxConns | int | `5` |  |
+| temporal.server.config.persistence.default.sql.maxIdleConns | int | `3` |  |
 | temporal.server.config.persistence.default.sql.maxConnLifetime | string | `"1h"` |  |
 | temporal.server.config.persistence.default.sql.tls.enabled | bool | `true` |  |
 | temporal.server.config.persistence.default.sql.tls.enableHostVerification | bool | `false` |  |
@@ -331,8 +331,8 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | temporal.server.config.persistence.visibility.sql.port | int | `5432` |  |
 | temporal.server.config.persistence.visibility.sql.user | string | `"postgres"` |  |
 | temporal.server.config.persistence.visibility.sql.existingSecret | string | `"fwinsights-postgresql"` |  |
-| temporal.server.config.persistence.visibility.sql.maxConns | int | `20` |  |
-| temporal.server.config.persistence.visibility.sql.maxIdleConns | int | `20` |  |
+| temporal.server.config.persistence.visibility.sql.maxConns | int | `5` |  |
+| temporal.server.config.persistence.visibility.sql.maxIdleConns | int | `3` |  |
 | temporal.server.config.persistence.visibility.sql.maxConnLifetime | string | `"1h"` |  |
 | temporal.server.config.persistence.visibility.sql.tls.enabled | bool | `true` |  |
 | temporal.server.config.persistence.visibility.sql.tls.enableHostVerification | bool | `false` |  |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -307,7 +307,6 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | temporal.mysql.enabled | bool | `false` |  |
 | temporal.postgresql.enabled | bool | `true` |  |
 | temporal.server.replicaCount | int | `1` |  |
-| temporal.server.config.logLevel | string | `"debug"` |  |
 | temporal.server.config.namespaces.create | bool | `true` |  |
 | temporal.server.config.namespaces.namespace[0].name | string | `"fwinsights"` |  |
 | temporal.server.config.namespaces.namespace[0].retention | string | `"3d"` |  |

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -822,8 +822,8 @@ temporal:
             existingSecret: fwinsights-postgresql
             # for a production deployment use this instead of `password` and provision the secret beforehand e.g. with a sealed secret
             # it has a single key called `password`
-            maxConns: 20
-            maxIdleConns: 20
+            maxConns: 5
+            maxIdleConns: 3
             maxConnLifetime: "1h"
             tls:
               enabled: true
@@ -843,8 +843,8 @@ temporal:
             existingSecret: fwinsights-postgresql
             # for a production deployment use this instead of `password` and provision the secret beforehand e.g. with a sealed secret
             # it has a single key called `password`
-            maxConns: 20
-            maxIdleConns: 20
+            maxConns: 5
+            maxIdleConns: 3
             maxConnLifetime: "1h"
             tls:
               enabled: true

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -805,7 +805,6 @@ temporal:
   server:
     replicaCount: 1
     config:
-      logLevel: "debug"
       namespaces:
         create: true
         namespace:


### PR DESCRIPTION
**Why This PR?**
- Lower temporal defaults connections per store - on staging it was spawning 40 connections.

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
