### PR TITLE
feat: allow separate superuser secret

### DIFF
--- a/stable/fairwinds-insights/templates/postgresql-cluster.yaml
+++ b/stable/fairwinds-insights/templates/postgresql-cluster.yaml
@@ -180,7 +180,7 @@ spec:
                   secret:
                     name: {{ .Values.postgresql.auth.existingSecret }}
               superuserSecret:
-                name: {{ .Values.postgresql.auth.existingSecret }}
+                name: {{ .Values.postgresql.auth.existingSuperUserSecret }}
               storage:
                 size: {{ .Values.postgresql.storage.size }}
                 storageClass: {{ .Values.postgresql.storage.storageClass }}

--- a/stable/fairwinds-insights/templates/secret.yml
+++ b/stable/fairwinds-insights/templates/secret.yml
@@ -16,12 +16,19 @@ type: Opaque
 apiVersion: v1
 data:
     {{- $password := b64enc (default (randAlphaNum 32) .Values.postgresql.auth.password) }}
-    postgresql-password: {{ $password }}
     password: {{ $password }}
     username: {{ b64enc .Values.postgresql.auth.username }}
 kind: Secret
 metadata:
     name: fwinsights-postgresql
+type: Opaque
+---
+apiVersion: v1
+data:
+    postgres: {{ default (randAlphaNum 32) .Values.postgresql.auth.superuserpassword }}
+kind: Secret
+metadata:
+    name: fwinsights-postgresql-superuser
 type: Opaque
 {{- end }}
 ---

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -526,6 +526,7 @@ postgresql:
     username: postgres
     database: fairwinds_insights
     existingSecret: fwinsights-postgresql
+    existingSuperUserSecret: fwinsights-postgresql-superuser
     secretKeys:
       adminPasswordKey: postgresql-password
   # -- PostgreSQL configuration parameters


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [ ] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
