### PR TITLE
[stable/fairwinds-insights] - add temporal host port

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## 4.1.0
+* Add support for `temporal.hostPort` and `temporal.namespace` 
+
 ## 4.0.5
-* Fixed go 1.25 cache diretory
+* Fixed go 1.25 cache directory
 
 ## 4.0.4
 * Fix temporal default postgres host

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "17.0"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 4.0.5
+version: 4.1.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -298,6 +298,8 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | repoScanJob.topologySpreadConstraints[1].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
 | repoScanJob.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"repo-scan-job"` |  |
 | repoScanJob.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
+| temporal.hostPort | string | `"insights-temporal-frontend:7233"` |  |
+| temporal.namespace | string | `"fwinsights"` |  |
 | temporal.enabled | bool | `false` |  |
 | temporal.fullnameOverride | string | `"insights-temporal"` |  |
 | temporal.cassandra.enabled | bool | `false` |  |

--- a/stable/fairwinds-insights/templates/_env.yaml
+++ b/stable/fairwinds-insights/templates/_env.yaml
@@ -211,4 +211,10 @@ env:
 - name: CRON_JOB_IMAGE_TAG
   value: {{ include "fairwinds-insights.cronjobImageTag" $ | quote }}
 
+# temporal specific
+- name: TEMPORAL_HOST_PORT
+  value: {{ $.Values.temporal.hostPort | quote }}
+- name: TEMPORAL_NAMESPACE
+  value: {{ $.Values.temporal.namespace | quote }}
+
 {{ end }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -820,6 +820,10 @@ repoScanJob:
           app.kubernetes.io/name: fairwinds-insights
 
 temporal:
+  # fairwinds-insights specific values - this will be inject as an env vars into fairwinds insights deployments
+  hostPort: "insights-temporal-frontend:7233"
+  namespace: "fwinsights"
+  # custom values from temporal chart
   enabled: false
   fullnameOverride: insights-temporal
   cassandra:


### PR DESCRIPTION
**Why This PR?**
* add temporal host port

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
