### PR TITLE
[stable/vpa] add in-place pod vertical scaling

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.8.1
+version: 4.9.0
 appVersion: 1.4.1
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -128,6 +128,24 @@ recommender:
     storage: prometheus
 ```
 
+## Utilize In-Place Pod Vertical Scaling
+
+Since version 1.4, VPA supports Kubernetes' in-place pod vertical scaling feature. To use this feature, you will need to
+
+- have a Kubernetes cluster supporting this feature (feature flag `InPlacePodVerticalScaling` enabled)
+- enable the VPA feature flag for updater and admission controller:
+  ```
+  admissionController:
+    extraArgs:
+      "feature-gates": "InPlaceOrRecreate=true"
+  updater:
+    extraArgs:
+      "feature-gates": "InPlaceOrRecreate=true"
+  ```
+- configure the respective VPA resources with `spec.updatePolicy.updateMode: "InPlaceOrRecreate"`
+
+For more information, see [VPA docs](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/features.md#in-place-updates-inplaceorrecreate) and [Kubernetes docs](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/).
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -138,12 +156,13 @@ recommender:
 | fullnameOverride | string | `""` | A template override for the fullname |
 | podLabels | object | `{}` | Labels to add to all pods |
 | rbac.create | bool | `true` | If true, then rbac resources (ClusterRoles and ClusterRoleBindings) will be created for the selected components. Temporary rbac resources will still be created, to ensure a functioning installation process |
-| rbac.extraRules | object | `{"vpaActor":[],"vpaCheckpointActor":[],"vpaEvictioner":[],"vpaMetricsReader":[],"vpaStatusActor":[],"vpaStatusReader":[],"vpaTargetReader":[]}` | Extra rbac rules for ClusterRoles |
+| rbac.extraRules | object | `{"vpaActor":[],"vpaCheckpointActor":[],"vpaEvictioner":[],"vpaMetricsReader":[],"vpaStatusActor":[],"vpaStatusReader":[],"vpaTargetReader":[],"vpaUpdaterInPlace":[]}` | Extra rbac rules for ClusterRoles |
 | rbac.extraRules.vpaActor | list | `[]` | Extra rbac rules for the vpa-actor ClusterRole |
 | rbac.extraRules.vpaStatusActor | list | `[]` | Extra rbac rules for the vpa-status-actor ClusterRole |
 | rbac.extraRules.vpaCheckpointActor | list | `[]` | Extra rbac rules for the vpa-checkpoint-actor ClusterRole |
 | rbac.extraRules.vpaEvictioner | list | `[]` | Extra rbac rules for the vpa-evictioner ClusterRole |
 | rbac.extraRules.vpaMetricsReader | list | `[]` | Extra rbac rules for the vpa-metrics-reader ClusterRole |
+| rbac.extraRules.vpaUpdaterInPlace | list | `[]` | Extra rbac rules for the vpa-updater-in-place ClusterRole |
 | rbac.extraRules.vpaTargetReader | list | `[]` | Extra rbac rules for the vpa-target-reader ClusterRole |
 | rbac.extraRules.vpaStatusReader | list | `[]` | Extra rbac rules for the vpa-status-reader ClusterRole |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created for each component |

--- a/stable/vpa/README.md.gotmpl
+++ b/stable/vpa/README.md.gotmpl
@@ -128,4 +128,22 @@ recommender:
     storage: prometheus
 ```
 
+## Utilize In-Place Pod Vertical Scaling
+
+Since version 1.4, VPA supports Kubernetes' in-place pod vertical scaling feature. To use this feature, you will need to
+
+- have a Kubernetes cluster supporting this feature (feature flag `InPlacePodVerticalScaling` enabled)
+- enable the VPA feature flag for updater and admission controller:
+  ```
+  admissionController:
+    extraArgs:
+      "feature-gates": "InPlaceOrRecreate=true"
+  updater:
+    extraArgs:
+      "feature-gates": "InPlaceOrRecreate=true"
+  ```
+- configure the respective VPA resources with `spec.updatePolicy.updateMode: "InPlaceOrRecreate"`
+
+For more information, see [VPA docs](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/features.md#in-place-updates-inplaceorrecreate) and [Kubernetes docs](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/).
+
 {{ template "chart.valuesSection" . }}

--- a/stable/vpa/crds/vpa-v1-crd.yaml
+++ b/stable/vpa/crds/vpa-v1-crd.yaml
@@ -428,6 +428,7 @@ spec:
                     - "Off"
                     - Initial
                     - Recreate
+                    - InPlaceOrRecreate
                     - Auto
                     type: string
                 type: object

--- a/stable/vpa/templates/clusterrolebindings.yaml
+++ b/stable/vpa/templates/clusterrolebindings.yaml
@@ -69,6 +69,19 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "vpa.serviceAccountName" . }}-updater
     namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vpa-updater-in-place-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vpa-updater-in-place
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "vpa.serviceAccountName" . }}-updater
+    namespace: {{ .Release.Namespace }}
 {{- end }}
 
 {{- if or .Values.recommender.enabled .Values.updater.enabled }}

--- a/stable/vpa/templates/clusterroles.yaml
+++ b/stable/vpa/templates/clusterroles.yaml
@@ -197,4 +197,20 @@ rules:
   {{- if .Values.rbac.extraRules.vpaStatusReader -}}
   {{ toYaml .Values.rbac.extraRules.vpaStatusReader | nindent 2 }}
   {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vpa-updater-in-place
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/resize
+      - pods # required for patching vpaInPlaceUpdated annotations onto the pod
+    verbs:
+      - patch
+  {{- if .Values.rbac.extraRules.vpaUpdaterInPlace -}}
+  {{ toYaml .Values.rbac.extraRules.vpaUpdaterInPlace | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -28,6 +28,8 @@ rbac:
     vpaEvictioner: []
     # rbac.extraRules.vpaMetricsReader -- Extra rbac rules for the vpa-metrics-reader ClusterRole
     vpaMetricsReader: []
+    # rbac.extraRules.vpaUpdaterInPlace -- Extra rbac rules for the vpa-updater-in-place ClusterRole
+    vpaUpdaterInPlace: []
     # rbac.extraRules.vpaTargetReader -- Extra rbac rules for the vpa-target-reader ClusterRole
     vpaTargetReader: []
     # rbac.extraRules.vpaStatusReader -- Extra rbac rules for the vpa-status-reader ClusterRole


### PR DESCRIPTION
**Why This PR?**
This PR enables the VPA chart to support in-place pod autoscaling which has been promoted to beta and is enabled by default in k8s 1.33

Fixes #1668

**Changes**
This effectively copies the changes from the upstream k8s resources and integrates them to the Helm chart.

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
