### PR TITLE
[stable/insights-agent] Default values for kube-bench securityContext

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.0.1
+* Added default values for kube-bench
+
 ## 5.0.0
 * Fix CI pipeline for kube-bench
  

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.0.0
+version: 5.0.1
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/kube-bench/_container.yaml
+++ b/stable/insights-agent/templates/kube-bench/_container.yaml
@@ -66,8 +66,8 @@ containers:
     readOnly: true
   securityContext:
     readOnlyRootFilesystem: true
-    allowPrivilegeEscalation: {{ (index .Values "kube-bench" "securityContext" "allowPrivilegeEscalation") | default false }}
-    privileged: {{ (index .Values "kube-bench" "securityContext" "privileged") | default false }}
+    allowPrivilegeEscalation: {{ if (index .Values "kube-bench" "securityContext") }}{{ (index .Values "kube-bench" "securityContext" "allowPrivilegeEscalation") | default false }}{{ else }}false{{ end }}
+    privileged: {{ if (index .Values "kube-bench" "securityContext") }}{{ (index .Values "kube-bench" "securityContext" "privileged") | default false }}{{ else }}false{{ end }}
     runAsNonRoot: false
     capabilities:
       drop:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -273,6 +273,9 @@ kube-bench:
     requests:
       cpu: 100m
       memory: 128Mi
+  securityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
 
 trivy:
   enabled: false


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
