### PR TITLE
[stable/gemini] using v1 in Helm post install notes

### DIFF
--- a/stable/gemini/Chart.yaml
+++ b/stable/gemini/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Automated backup and restore of PersistentVolumes using the VolumeSnapshot API
 name: gemini
-version: 2.1.3
+version: 2.1.4
 appVersion: "2.0"
 kubeVersion: ">= 1.22.0-0"
 maintainers:

--- a/stable/gemini/templates/NOTES.txt
+++ b/stable/gemini/templates/NOTES.txt
@@ -3,7 +3,7 @@ Gemini is now installed!
 To start using Gemini, create a SnapshotGroup. You can use an
 existing PVC, or ask Gemini to create one for you.
 
-apiVersion: gemini.fairwinds.com/v1beta1
+apiVersion: gemini.fairwinds.com/v1
 kind: SnapshotGroup
 metadata:
   name: test-volume


### PR DESCRIPTION
**Why This PR?**
_if anyone uses this chart, the post install notes should advise the user to use v1 not v1beta1_

**Fixes**
just uses the v1 apiVersion in notes.txt

**Changes**
no functional changes

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
