### PR TITLE
[stable/fairwinds-insights] Add one-time migration job configuration and template

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 5.1.0
-* Adds and enable `one-time-migration` job to helm pre-hook
+* Adds and enable `one-time-migration` job to helm hook
 
 ## 5.0.3
 * Adds and enable `general-worker` temporal deployment

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.1.0
+* Adds and enable `one-time-migration` job to helm pre-hook
+
 ## 5.0.3
 * Adds and enable `general-worker` temporal deployment
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.1"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 5.0.3
+version: 5.1.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -132,6 +132,9 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | openApi.service.type | string | `nil` | Service type for Open API server |
 | dbMigration.resources | object | `{"limits":{"cpu":1,"memory":"1024Mi"},"requests":{"cpu":"80m","memory":"128Mi"}}` | Resources for the database migration job. |
 | dbMigration.securityContext.runAsUser | int | `10324` | The user ID to run the database migration job under. |
+| oneTimeMigration.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resources for the one time migration job. |
+| oneTimeMigration.securityContext.runAsUser | int | `10324` | The user ID to run the migration job under. |
+| oneTimeMigration.additionalEnv | list | `[{"name":"POSTGRES_MAX_IDLE_CONNS","value":"1"},{"name":"POSTGRES_MAX_OPEN_CONNS","value":"1"}]` | Additional environment variables for the one time migration job. |
 | service.port | int | `80` | Port to be used for the API and Dashboard services. |
 | service.type | string | `"ClusterIP"` | Service type for the API and Dashboard services |
 | service.annotations | string | `nil` | Annotations for the services |

--- a/stable/fairwinds-insights/templates/one-time-migration-job.yaml
+++ b/stable/fairwinds-insights/templates/one-time-migration-job.yaml
@@ -4,12 +4,8 @@ metadata:
   name: one-time-migration
   annotations:
     "helm.sh/hook-delete-policy": "before-hook-creation"
-    "helm.sh/hook-weight": "1" # run after the database migration job
-  {{- if not (or .Values.postgresql.ephemeral .Values.postgresql.postMigrate) }}
-    "helm.sh/hook": "pre-install,pre-upgrade"
-  {{- else }}
+    "helm.sh/hook-weight": "1"
     "helm.sh/hook": "post-install,post-upgrade"
-  {{- end }}
   labels:
     {{- include "fairwinds-insights.labels" . | nindent 4 }}
     app.kubernetes.io/component: one-time-migration

--- a/stable/fairwinds-insights/templates/one-time-migration-job.yaml
+++ b/stable/fairwinds-insights/templates/one-time-migration-job.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: one-time-migration
+  annotations:
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "1" # run after the database migration job
+  {{- if not (or .Values.postgresql.ephemeral .Values.postgresql.postMigrate) }}
+    "helm.sh/hook": "pre-install,pre-upgrade"
+  {{- else }}
+    "helm.sh/hook": "post-install,post-upgrade"
+  {{- end }}
+  labels:
+    {{- include "fairwinds-insights.labels" . | nindent 4 }}
+    app.kubernetes.io/component: one-time-migration
+spec:
+  backoffLimit: 5
+  template:
+    spec:
+      restartPolicy: Never
+      {{- with .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
+      containers:
+      - name: fwinsights-one-time-migration
+        image: "{{ .Values.cronjobImage.repository }}:{{ include "fairwinds-insights.cronjobImageTag" . }}"
+        imagePullPolicy: Always
+        command: ["one_time_migration"]
+        resources:
+          {{- toYaml .Values.oneTimeMigration.resources | nindent 10 }}
+        {{- include "env" (dict "root" .) | indent 8 }}
+        {{- with .Values.oneTimeMigration.additionalEnv }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsNonRoot: false
+          runAsUser: {{ .Values.oneTimeMigration.securityContext.runAsUser }}
+          capabilities:
+            drop:
+              - ALL

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -443,6 +443,25 @@ dbMigration:
     # -- The user ID to run the database migration job under.
     runAsUser: 10324
 
+oneTimeMigration:
+  # -- Resources for the one time migration job.
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  securityContext:
+    # -- The user ID to run the migration job under.
+    runAsUser: 10324
+  # -- Additional environment variables for the one time migration job.
+  additionalEnv:
+    - name: POSTGRES_MAX_IDLE_CONNS
+      value: "1"
+    - name: POSTGRES_MAX_OPEN_CONNS
+      value: "1"
+
 service:
   # -- Port to be used for the API and Dashboard services.
   port: 80


### PR DESCRIPTION
**Why This PR?**
- Add and enable one-time migration job configuration and template

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
