### PR TITLE
[stable/fairwinds-insights] add api.additionalEnvVars

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## 5.3.0
+* Add `additionalEnvVars` on the `api` and defaults for `POSTGRES_MAX_IDLE_CONNS` and `POSTGRES_MAX_OPEN_CONNS`
+
 ## 5.2.0
-* Remove `cronjobs.alerts-realtime` and `notifications-digest` cronjobs in favor or temporal schedulers approach.
+* Remove `cronjobs.alerts-realtime` and `cronjobs.notifications-digest` cronjobs in favor or temporal schedulers approach.
 
 ## 5.1.0
 * Adds and enable `one-time-migration` job to helm hook

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.1"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 5.2.0
+version: 5.3.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -106,6 +106,10 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | api.securityContext.runAsUser | int | `10324` | The user ID to run the API server under. |
 | api.ingress.enabled | bool | `true` | Enable the Open API ingress |
 | api.service.type | string | `nil` | Service type for Open API server |
+| api.additionalEnvVars[0].name | string | `"POSTGRES_MAX_IDLE_CONNS"` |  |
+| api.additionalEnvVars[0].value | string | `"5"` |  |
+| api.additionalEnvVars[1].name | string | `"POSTGRES_MAX_OPEN_CONNS"` |  |
+| api.additionalEnvVars[1].value | string | `"15"` |  |
 | openApi.port | int | `8080` | Port for the Open API server to listen on. |
 | openApi.pdb.enabled | bool | `false` | Create a pod disruption budget for the Open API server. |
 | openApi.pdb.minReplicas | int | `1` | How many replicas should always exist for the Open API server. |

--- a/stable/fairwinds-insights/templates/deployment-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-api.yaml
@@ -39,6 +39,9 @@ spec:
             containerPort: {{ .Values.api.port }}
             protocol: TCP
           {{- include "env" (dict "root" .) | indent 10 }}
+          {{- with .Values.api.additionalEnvVars }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /livez

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -353,6 +353,11 @@ api:
   service:
     # -- Service type for Open API server
     type:
+  additionalEnvVars:
+    - name: POSTGRES_MAX_IDLE_CONNS
+      value: "5"
+    - name: POSTGRES_MAX_OPEN_CONNS
+      value: "15"
 
 openApi:
   # -- Port for the Open API server to listen on.


### PR DESCRIPTION
**Why This PR?**
Internal INS-1486

Fixes #

**Changes**
Changes proposed in this pull request:

* This is the current default on the backend that will be downgraded in the future
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
