### PR TITLE
INS-1515 - use custom service account if custom rbac is enabled

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.4.1
+* Use the correct service-account on custom RBAC definition for temporal deployments
+
 ## 5.4.0
 * Adds and enable `github-worker` temporal deployment
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.1"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 5.4.0
+version: 5.4.1
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/templates/deployment-temporal-worker.yaml
+++ b/stable/fairwinds-insights/templates/deployment-temporal-worker.yaml
@@ -35,7 +35,11 @@ spec:
       imagePullSecrets:
         - name: {{ . }}
       {{- end }}
+      {{- if (and $options.rbac $options.rbac.enabled) | default $.Values.temporalDeploymentDefaults.rbac.enabled }}
+      serviceAccountName: {{ include "fairwinds-insights.fullname" $ }}-{{ $name }}
+      {{- else }}
       serviceAccountName: {{ include "fairwinds-insights.fullname" $ }}-insights
+      {{- end }}
       containers:
         - name: fairwinds-insights
           image: "{{ $.Values.apiImage.repository }}:{{ include "fairwinds-insights.apiImageTag" $ }}"


### PR DESCRIPTION
**Why This PR?**
- Use custom service account if custom rbac is enabled

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
