### PR TITLE
INS-1583: Remove parameter maxMemoryMB from insights event watcher

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.2.4
+* Removed insights event watcher parameter
+
 ## 5.2.3
 * Fix insights event watcher parameters
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.2.3
+version: 5.2.4
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/insights-event-watcher/deployment.yaml
+++ b/stable/insights-agent/templates/insights-event-watcher/deployment.yaml
@@ -51,9 +51,6 @@ spec:
         - --console
         {{- end }}
         - --poll-interval={{ (index .Values "insights-event-watcher" "pollInterval") | default "15s" }}
-        {{- if (index .Values "insights-event-watcher" "cloudwatch" "maxMemoryMB") }}
-        - --max-memory={{ (index .Values "insights-event-watcher" "cloudwatch" "maxMemoryMB") }}
-        {{- end }}
         {{- if (index .Values "insights-event-watcher" "cloudwatch" "batchSize") }}
         - --batch-size={{ (index .Values "insights-event-watcher" "cloudwatch" "batchSize") }}
         {{- end }}


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
