### PR TITLE
[stable/vpa] support cert-manager ca bundle for webhook test

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.9.0
+version: 4.10.0
 appVersion: 1.4.1
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/tests/webhook.yaml
+++ b/stable/vpa/templates/tests/webhook.yaml
@@ -50,6 +50,16 @@ spec:
             {{ include "vpa.webhook.secret" . }} \
             -o=jsonpath="{.data.ca}")
 
+          # Get CA bundle if using cert-manager
+          if [ -z "$SECRET_CABUNDLE" ]
+          then
+            SECRET_CABUNDLE=$(kubectl \
+              get secret \
+              -n {{ .Release.Namespace }} \
+              {{ include "vpa.webhook.secret" . }} \
+              -o=jsonpath="{.data.ca\.crt}")
+          fi
+
           # Get configured CA bundle
           WEBHOOK_CABUNDLE=$(kubectl \
             get mutatingwebhookconfigurations.admissionregistration.k8s.io \


### PR DESCRIPTION
**Why This PR?**
Allow webhook Helm test to succeed when cert-manager generated Secret is used as source for webhook CA

Fixes #1696

**Changes**
Changes proposed in this pull request:

* Add fallback from Secret property `ca` to property `ca.crt`

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
