### PR TITLE
[stable/vpa] Add the ability to define a custom namespace to deploy the objects into

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Guidelines on Contributing
 
 * Lint your changes:
-  * `docker run --rm -it -v ${PWD}:/charts -w /charts quay.io/helmpack/chart-testing:v3.14.0 ct lint --chart-yaml-schema scripts/schema.yaml --chart-dirs incubator --chart-dirs stable`
+  * `docker run --rm -it -v ${PWD}:/charts -w /charts quay.io/helmpack/chart-testing:v3.14.0 ct lint --chart-yaml-schema scripts/schema.yaml --chart-dirs incubator --chart-dirs stable --config scripts/ct.yaml`
 * End-to-end test your changes:
   * Install [kind 0.7.0+](https://github.com/kubernetes-sigs/kind/releases)
   * Install [chart-testing (ct)](https://github.com/helm/chart-testing/releases)

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.10.0
+version: 4.10.1
 appVersion: 1.4.1
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- .Values.admissionController.annotations | toYaml | nindent 4 }}
   {{- end }}
   name: {{ include "vpa.fullname" . }}-admission-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: admission-controller
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/admission-controller-pdb.yaml
+++ b/stable/vpa/templates/admission-controller-pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" 
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "vpa.fullname" . }}-admission-controller-pdb"
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- toYaml .Values.admissionController.podDisruptionBudget | nindent 2 }}
   selector:

--- a/stable/vpa/templates/admission-controller-service-account.yaml
+++ b/stable/vpa/templates/admission-controller-service-account.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "vpa.serviceAccountName" . }}-admission-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-controller

--- a/stable/vpa/templates/admission-controller-service.yaml
+++ b/stable/vpa/templates/admission-controller-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "vpa.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - port: 443

--- a/stable/vpa/templates/recommender-deployment.yaml
+++ b/stable/vpa/templates/recommender-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- .Values.recommender.annotations | toYaml | nindent 4 }}
   {{- end }}
   name: {{ include "vpa.fullname" . }}-recommender
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: recommender
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/recommender-pdb.yaml
+++ b/stable/vpa/templates/recommender-pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" 
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "vpa.fullname" . }}-recommender-pdb"
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- toYaml .Values.recommender.podDisruptionBudget | nindent 2 }}
   selector:

--- a/stable/vpa/templates/recommender-podmonitor.yaml
+++ b/stable/vpa/templates/recommender-podmonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "vpa.fullname" . }}-recommender
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.recommender.podMonitor.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/stable/vpa/templates/recommender-service-account.yaml
+++ b/stable/vpa/templates/recommender-service-account.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "vpa.serviceAccountName" . }}-recommender
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
     app.kubernetes.io/component: recommender

--- a/stable/vpa/templates/updater-deployment.yaml
+++ b/stable/vpa/templates/updater-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- .Values.updater.annotations | toYaml | nindent 4 }}
   {{- end }}
   name: {{ include "vpa.fullname" . }}-updater
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: updater
     {{- include "vpa.labels" . | nindent 4 }}

--- a/stable/vpa/templates/updater-pdb.yaml
+++ b/stable/vpa/templates/updater-pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" 
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "vpa.fullname" . }}-updater-pdb"
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- toYaml .Values.updater.podDisruptionBudget | nindent 2 }}
   selector:

--- a/stable/vpa/templates/updater-podmonitor.yaml
+++ b/stable/vpa/templates/updater-podmonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "vpa.fullname" . }}-updater
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.updater.podMonitor.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/stable/vpa/templates/updater-service-account.yaml
+++ b/stable/vpa/templates/updater-service-account.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "vpa.serviceAccountName" . }}-updater
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
     app.kubernetes.io/component: updater


### PR DESCRIPTION
### Why This PR?

The VPA chart does not currently support the ability to deploy its associated Kubernetes objects (deployments, PDBs, etc.) into a custom namespace. It will, by default, deploy all resources to `default`. We are submitting this PR so that we can allow for users to designate a custom namespace for the following templated resources under the VPA chart:

* Admission Controller:
  * `admission-controller-deployment.yaml`
  * `admission-controller-pdb.yaml`
  * `admission-controller-service-account.yaml`
  * `admission-controller-service.yaml`
* Recommender:
  * `recommender-deployment.yaml`
  * `recommender-pdb.yaml`
  * `recommender-podmonitor.yaml`
  * `recommender-service-account.yaml`
* Updater:
  * `updater-deployment.yaml`
  * `updater-pdb.yaml`
  * `updater-podmonitor.yaml`
  * `updater-service-account.yaml`

### Notes:
* `{{ .Release.Namespace }}` should be backwards compatible as the value defaults to `default` if unset. No new values are being set.
* I've read through the code pretty extensively but I'm not a maintainer (just someone who is using this Helm chart). There are a few issues I've encountered so far, namely:
  * ClusterRoleBindings, oddly, reference `{{ Release.Namespace }}`. When the Namespace value is set, it then references _nothing_. 
https://github.com/FairwindsOps/charts/blob/4168b92dec85ad00a784dc151fe51f171374e5d2/stable/vpa/templates/clusterrolebindings.yaml#L101-L134

If any of these "issues" I've found are actually intended, please let me know! 

### Changes:
Changes proposed in this pull request:

* Adds the ability to set the VPA's namespace to something other than `default` by referencing `.Release.Namespace` in Gomplate. This change affects the Admission Controller, Recommender, and Updater.

### Checklist:

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
