### PR TITLE
[stable/fairwinds-insights]: adds ttlSecondsAfterFinished

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 5.4.3
-* Replaced "helm.sh/hook-delete-policy": "before-hook-creation" with "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed" for one-time-migration and migrate-db jobs.
+* Replaced `"helm.sh/hook-delete-policy": "before-hook-creation"` with `"helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"` for `one-time-migration` and `migrate-db` jobs.
 
 ## 5.4.2
 * Remove deployments that were moved to temporal workflows (`repo-scan-job` and `automated-pr-job`)

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.4.3
+* Replaced "helm.sh/hook-delete-policy": "before-hook-creation" with "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed" for one-time-migration and migrate-db jobs.
+
 ## 5.4.2
 * Remove deployments that were moved to temporal workflows (`repo-scan-job` and `automated-pr-job`)
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "18.1"
+appVersion: "18.2"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 5.4.2
+version: 5.4.3
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "18.2"
+appVersion: "18.1"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
 version: 5.4.3

--- a/stable/fairwinds-insights/templates/migrate-db-job.yaml
+++ b/stable/fairwinds-insights/templates/migrate-db-job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: migrate-database
   annotations:
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
   {{- if not (or .Values.postgresql.ephemeral .Values.postgresql.postMigrate) }}
     "helm.sh/hook": "pre-install,pre-upgrade"
   {{- else }}

--- a/stable/fairwinds-insights/templates/migrate-db-job.yaml
+++ b/stable/fairwinds-insights/templates/migrate-db-job.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- include "fairwinds-insights.labels" . | nindent 4 }}
     app.kubernetes.io/component: migrate-db
 spec:
+  ttlSecondsAfterFinished: 3600
   backoffLimit: 5
   template:
     spec:

--- a/stable/fairwinds-insights/templates/migrate-db-job.yaml
+++ b/stable/fairwinds-insights/templates/migrate-db-job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: migrate-database
   annotations:
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   {{- if not (or .Values.postgresql.ephemeral .Values.postgresql.postMigrate) }}
     "helm.sh/hook": "pre-install,pre-upgrade"
   {{- else }}

--- a/stable/fairwinds-insights/templates/one-time-migration-job.yaml
+++ b/stable/fairwinds-insights/templates/one-time-migration-job.yaml
@@ -10,6 +10,7 @@ metadata:
     {{- include "fairwinds-insights.labels" . | nindent 4 }}
     app.kubernetes.io/component: one-time-migration
 spec:
+  ttlSecondsAfterFinished: 3600
   backoffLimit: 5
   template:
     spec:

--- a/stable/fairwinds-insights/templates/one-time-migration-job.yaml
+++ b/stable/fairwinds-insights/templates/one-time-migration-job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: one-time-migration
   annotations:
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
     "helm.sh/hook-weight": "1"
     "helm.sh/hook": "post-install,post-upgrade"
   labels:

--- a/stable/fairwinds-insights/templates/one-time-migration-job.yaml
+++ b/stable/fairwinds-insights/templates/one-time-migration-job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: one-time-migration
   annotations:
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
     "helm.sh/hook-weight": "1"
     "helm.sh/hook": "post-install,post-upgrade"
   labels:


### PR DESCRIPTION
**Why This PR?**
We will change hook delete policy so that helm release pruner can delete old releases.

Fixes #
replaced "helm.sh/hook-delete-policy": "before-hook-creation" with "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed" for one-time-migration and migrate-db jobs.
**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
