### PR TITLE
[stable/helm-release-pruner]: set dryRun to false for actual pruning

### DIFF
--- a/stable/helm-release-pruner/Chart.yaml
+++ b/stable/helm-release-pruner/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v3.4.0
+appVersion: v3.4.1
 description: This chart deploys a cronjob that purges stale Helm releases and associated namespaces. Releases are selected based on regex patterns for release name and namespace along with a Bash `date` command date string to define the stale cutoff date and time.
 name: helm-release-pruner
 version: 3.4.1

--- a/stable/helm-release-pruner/Chart.yaml
+++ b/stable/helm-release-pruner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v3.4.0
 description: This chart deploys a cronjob that purges stale Helm releases and associated namespaces. Releases are selected based on regex patterns for release name and namespace along with a Bash `date` command date string to define the stale cutoff date and time.
 name: helm-release-pruner
-version: 3.4.0
+version: 3.4.1
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/helm-release-pruner/Chart.yaml
+++ b/stable/helm-release-pruner/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v3.4.1
+appVersion: v3.4.0
 description: This chart deploys a cronjob that purges stale Helm releases and associated namespaces. Releases are selected based on regex patterns for release name and namespace along with a Bash `date` command date string to define the stale cutoff date and time.
 name: helm-release-pruner
 version: 3.4.1

--- a/stable/helm-release-pruner/ci/test-values.yaml
+++ b/stable/helm-release-pruner/ci/test-values.yaml
@@ -1,5 +1,6 @@
 job:
   debug: true
+  dryRun: false # If true, will only log candidates for removal and not remove them. Set to false for actual pruning.
 pruneProfiles:
 - olderThan: "3 days ago"
   helmReleaseFilter: "^fwinsights-"

--- a/stable/helm-release-pruner/ci/test-values.yaml
+++ b/stable/helm-release-pruner/ci/test-values.yaml
@@ -1,6 +1,6 @@
 job:
   debug: true
-  dryRun: false # If true, will only log candidates for removal and not remove them. Set to false for actual pruning.
+  dryRun: false  # If true, will only log candidates for removal and not remove them. Set to false for actual pruning.
 pruneProfiles:
 - olderThan: "3 days ago"
   helmReleaseFilter: "^fwinsights-"


### PR DESCRIPTION
**Why This PR?**
The Release Pruner's job was set to `dryRun: true`, which only logs candidates for removal without actually removing them. We will set dryRun to false for `helm-release-pruner` `ci` job for actual pruning.

Fixes #

**Changes**
dryRun is set to false for stable/helm-release-pruner/ci/test-values.yaml

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
