### PR TITLE
update k8s testing versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,29 +131,29 @@ workflows:
       - lint-scripts
       - lint-charts
       - rok8s/kubernetes_e2e_tests:
-          name: "End-To-End Kubernetes 1.30"
-          kind_node_image: "kindest/node:v1.30.13@sha256:397209b3d947d154f6641f2d0ce8d473732bd91c87d9575ade99049aa33cd648"
-          checkout-method: full
-          executor:
-            name: ci-images-xlarge
-          <<: *kind_configuration_helm3
-      - rok8s/kubernetes_e2e_tests:
-          name: "End-To-End Kubernetes 1.31"
-          kind_node_image: "kindest/node:v1.31.12@sha256:0f5cc49c5e73c0c2bb6e2df56e7df189240d83cf94edfa30946482eb08ec57d2"
-          checkout-method: full
-          executor:
-            name: ci-images-xlarge
-          <<: *kind_configuration_helm3
-      - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.32"
-          kind_node_image: "kindest/node:v1.32.8@sha256:abd489f042d2b644e2d033f5c2d900bc707798d075e8186cb65e3f1367a9d5a1"
+          kind_node_image: "kindest/node:v1.32.11@sha256:5fc52d52a7b9574015299724bd68f183702956aa4a2116ae75a63cb574b35af8"
           checkout-method: full
           executor:
             name: ci-images-xlarge
           <<: *kind_configuration_helm3
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.33"
-          kind_node_image: "kindest/node:v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2"
+          kind_node_image: "kindest/node:v1.33.7@sha256:d26ef333bdb2cbe9862a0f7c3803ecc7b4303d8cea8e814b481b09949d353040"
+          checkout-method: full
+          executor:
+            name: ci-images-xlarge
+          <<: *kind_configuration_helm3
+      - rok8s/kubernetes_e2e_tests:
+          name: "End-To-End Kubernetes 1.34"
+          kind_node_image: "kindest/node:v1.34.3@sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48"
+          checkout-method: full
+          executor:
+            name: ci-images-xlarge
+          <<: *kind_configuration_helm3
+      - rok8s/kubernetes_e2e_tests:
+          name: "End-To-End Kubernetes 1.35"
+          kind_node_image: "kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661"
           checkout-method: full
           executor:
             name: ci-images-xlarge


### PR DESCRIPTION
**Why This PR?**
Update k8s testing versions

- Add: 1.34 and 1.35
- Removed Not supported: 1.30 and 1.31

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
