### PR TITLE
[stable/insights-agent] INS-2265: Bump charts images

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.1.4
+* Bumped image from `alpine/kubectl:1.35.3` to `alpine/kubectl:1.35.4`
+
 ## 8.1.3
 * Bumped images for fixing vulnerabilities 
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.3"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 8.1.3
+version: 8.1.4
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -267,7 +267,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | migrateHealthScoreJob.resources.requests.cpu | string | `"80m"` |  |
 | migrateHealthScoreJob.resources.requests.memory | string | `"128Mi"` |  |
 | cronjobExecutor.image.repository | string | `"alpine/kubectl"` |  |
-| cronjobExecutor.image.tag | string | `"1.35.3"` |  |
+| cronjobExecutor.image.tag | string | `"1.35.4"` |  |
 | cronjobExecutor.resources.limits.cpu | string | `"100m"` |  |
 | cronjobExecutor.resources.limits.memory | string | `"64Mi"` |  |
 | cronjobExecutor.resources.requests.cpu | string | `"1m"` |  |

--- a/stable/fairwinds-insights/templates/postgresql-cluster.yaml
+++ b/stable/fairwinds-insights/templates/postgresql-cluster.yaml
@@ -106,7 +106,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: create-cluster
-        image: "alpine/kubectl:1.35.3"
+        image: "alpine/kubectl:1.35.4"
         command: ["sh"]
         args:
           - -c

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -850,7 +850,7 @@ migrateHealthScoreJob:
 cronjobExecutor:
   image:
     repository: alpine/kubectl
-    tag: "1.35.3"
+    tag: "1.35.4"
   resources:
     limits:
       cpu: 100m

--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,12 +1,8 @@
 # Changelog
 
-## 1.12.3
-* Pinned CI test image to `python:3.14.4-alpine3.23` (latest `library/python` patch + Alpine variant on Docker Hub)
-
-## 1.12.2
-* Bumped CI test image default to `python:3.13-alpine`
-
 ## 1.12.1
+* Pinned CI test image to `python:3.14.4-alpine3.23`
+* Bumped CI test image default to `python:3.13-alpine`
 * Bumped CI test image default from `python:3.10-alpine` to `python:3.12-alpine`
 
 ## 1.12.0

--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Pinned CI test image to `python:3.14.4-alpine3.23`
 * Bumped CI test image default to `python:3.13-alpine`
 * Bumped CI test image default from `python:3.10-alpine` to `python:3.12-alpine`
+* Bumped image from alpine/kubectl:1.35.3 to alpine/kubectl:1.35.4
 
 ## 1.12.0
 * Set explicit `spec.privateKey.rotationPolicy` on the cert-manager Certificate for cert-manager v1.18.0+ compatibility (configurable via `privateKeyRotationPolicy`).

--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.12.3
+* Pinned CI test image to `python:3.14.4-alpine3.23` (latest `library/python` patch + Alpine variant on Docker Hub)
+
+## 1.12.2
+* Bumped CI test image default to `python:3.13-alpine`
+
+## 1.12.1
+* Bumped CI test image default from `python:3.10-alpine` to `python:3.12-alpine`
+
 ## 1.12.0
 * Set explicit `spec.privateKey.rotationPolicy` on the cert-manager Certificate for cert-manager v1.18.0+ compatibility (configurable via `privateKeyRotationPolicy`).
 

--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Pinned CI test image to `python:3.14.4-alpine3.23`
 * Bumped CI test image default to `python:3.13-alpine`
 * Bumped CI test image default from `python:3.10-alpine` to `python:3.12-alpine`
-* Bumped image from alpine/kubectl:1.35.3 to alpine/kubectl:1.35.4
+* Bumped image from `alpine/kubectl:1.35.3` to `alpine/kubectl:1.35.4`
 
 ## 1.12.0
 * Set explicit `spec.privateKey.rotationPolicy` on the cert-manager Certificate for cert-manager v1.18.0+ compatibility (configurable via `privateKeyRotationPolicy`).

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.12.0
+version: 1.12.3
 appVersion: "2.2"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.12.3
+version: 1.12.1
 appVersion: "2.2"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -102,4 +102,4 @@ rules:
 | certManagerApiVersion | string | `""` | If secretName is empty, we assume that you use cert-manager to provision the admission controller certificates. This allows pinning the apiVersion rather than using helm capabilities detection. Useful for gitops tools such as ArgoCD |
 | privateKeyRotationPolicy | string | `"Always"` | cert-manager Certificate `spec.privateKey.rotationPolicy`. In cert-manager v1.18.0+ the default is `Always` (it was `Never` before). Set explicitly to silence warnings and pin behavior. Use `Always` to match the new default or `Never` for the pre-1.18 behavior. |
 | polaris.config | string | `nil` | Configuration for Polaris |
-| test | object | `{"enabled":false,"image":{"repository":"python","tag":"3.10-alpine"}}` | Used for chart CI only - deploys a test deployment |
+| test | object | `{"enabled":false,"image":{"repository":"python","tag":"3.14.4-alpine3.23"}}` | Used for chart CI only - deploys a test deployment |

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -253,4 +253,4 @@ test:
   enabled: false
   image:
     repository: "python"
-    tag: "3.10-alpine"
+    tag: "3.14.4-alpine3.23"

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.6.4
+* Bumped workloads plugin to `2.9` and prometheus-collector to `1.9`
+
 ## 5.6.3
 * Bumped goldilocks subchart to `10.3.*`, prometheus to `28.14.*`, and dcgm-exporter to `4.8.1`
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.6.3
+version: 5.6.4
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -212,7 +212,7 @@ workloads:
   timeout: 300
   image:
     repository: quay.io/fairwinds/workloads
-    tag: "2.8"
+    tag: "2.9"
   resources:
     requests:
       cpu: 100m
@@ -342,7 +342,7 @@ prometheus-metrics:
   tenantId: ""
   image:
     repository: quay.io/fairwinds/prometheus-collector
-    tag: "1.8"
+    tag: "1.9"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
