### PR TITLE
Update charts to use latest polaris

### DIFF
--- a/stable/polaris/CHANGELOG.md
+++ b/stable/polaris/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this chart adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 6.0.0
+* **Breaking:** Default container image is now `us-docker.pkg.dev/fairwinds-ops/oss/polaris`; `quay.io/fairwinds/polaris` is deprecated upstream as of Polaris [v10.2.0](https://github.com/FairwindsOps/polaris/releases/tag/v10.2.0). Set `image.repository` (and `image.tag` if needed) to remain on Quay while you migrate.
+* Update Polaris to 10.2.0.
+* Add support for `appVersion` be written with or without a leading `v` when `image.tag` is unset.
+
 ## 5.17.0
 * Removed the switch for networking apiVersion and default to networking/v1
 

--- a/stable/polaris/Chart.yaml
+++ b/stable/polaris/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Validation of best practices in your Kubernetes clusters
 name: polaris
-version: 5.19.0
-appVersion: "9.6"
+version: 6.0.0
+appVersion: "10.2.0"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/polaris/master/pkg/dashboard/assets/favicon-32x32.png
 maintainers:

--- a/stable/polaris/README.md
+++ b/stable/polaris/README.md
@@ -39,7 +39,7 @@ the 0.10.0 version of this chart will only work on kubernetes 1.14.0+
 | configUrl | string | `nil` | Use a config from an accessible URL source.  NOTE: `config` & `configUrl` are mutually exclusive.  Setting `configURL` will take precedence over `config`.  Only one may be used. configUrl: https://example.com/config.yaml |
 | additionalExemptions | string | `nil` | List of additional exemptions to append to the exemptions given in `config` |
 | mergeConfig | bool | `false` | If the config should be merged with the default config. See https://github.com/FairwindsOps/polaris/pull/1075 |
-| image.repository | string | `"quay.io/fairwinds/polaris"` | Image repo |
+| image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/polaris"` | Image repo |
 | image.tag | string | `""` | The Polaris Image tag to use. Defaults to the Chart's AppVersion |
 | image.pullPolicy | string | `"Always"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Image pull secrets |

--- a/stable/polaris/templates/_helpers.tpl
+++ b/stable/polaris/templates/_helpers.tpl
@@ -68,3 +68,19 @@ Name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Polaris OSS images use v-prefixed semver tags on Artifact Registry (e.g. v10.2.0).
+*/}}
+{{- define "polaris.imageTag" -}}
+{{- if .Values.image.tag -}}
+{{- .Values.image.tag -}}
+{{- else -}}
+{{- $v := .Chart.AppVersion -}}
+{{- if hasPrefix "v" $v -}}
+{{- $v -}}
+{{- else -}}
+{{- printf "v%s" $v -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/stable/polaris/templates/audit.job.yaml
+++ b/stable/polaris/templates/audit.job.yaml
@@ -30,7 +30,7 @@ spec:
         - --config
         - /opt/app/config.yaml
         {{- end }}
-        image: '{{.Values.image.repository}}:{{ .Values.image.tag | default .Chart.AppVersion }}'
+        image: '{{.Values.image.repository}}:{{ include "polaris.imageTag" . }}'
         imagePullPolicy: '{{.Values.image.pullPolicy}}'
         name: audit
         resources:

--- a/stable/polaris/templates/dashboard.deployment.yaml
+++ b/stable/polaris/templates/dashboard.deployment.yaml
@@ -82,7 +82,7 @@ spec:
         {{- if .Values.mergeConfig }}
         - --merge-config
         {{- end }}
-        image: '{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion }}'
+        image: '{{.Values.image.repository}}:{{ include "polaris.imageTag" . }}'
         imagePullPolicy: '{{.Values.image.pullPolicy}}'
         name: dashboard
         ports:

--- a/stable/polaris/templates/webhook.deployment.yaml
+++ b/stable/polaris/templates/webhook.deployment.yaml
@@ -55,7 +55,7 @@ spec:
             {{- if .Values.webhook.logLevel }}
             - --log-level={{ .Values.webhook.logLevel }}
             {{- end }}
-          image: '{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion }}'
+          image: '{{.Values.image.repository}}:{{ include "polaris.imageTag" . }}'
           imagePullPolicy: '{{.Values.image.pullPolicy}}'
           ports:
             - containerPort: 9876

--- a/stable/polaris/values.yaml
+++ b/stable/polaris/values.yaml
@@ -14,7 +14,7 @@ mergeConfig: false
 
 image:
   # image.repository -- Image repo
-  repository: quay.io/fairwinds/polaris
+  repository: us-docker.pkg.dev/fairwinds-ops/oss/polaris
   # image.tag -- The Polaris Image tag to use. Defaults to the Chart's AppVersion
   tag: ""
   # image.pullPolicy -- Image pull policy


### PR DESCRIPTION
**Why This PR?**
* **Breaking:** Default container image is now `us-docker.pkg.dev/fairwinds-ops/oss/polaris`; `quay.io/fairwinds/polaris` is deprecated upstream as of Polaris [v10.2.0](https://github.com/FairwindsOps/polaris/releases/tag/v10.2.0). Set `image.repository` (and `image.tag` if needed) to remain on Quay while you migrate.
* Update Polaris to v10.2.0.
* Add support for `appVersion` be written with or without a leading `v` when `image.tag` is unset.

Fixes https://github.com/FairwindsOps/charts/issues/1805

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
