### PR TITLE
[stable/fairwinds-insights] INS-2337: External secret must be annotated with pre-install

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.2.1
+* Added pre-install for external secret
+
 ## 9.2.0
 * Switch self-hosted image defaults from Quay (`quay.io/fairwinds/`) to Google Artifact Registry (`us-docker.pkg.dev/fairwinds-ops/insights/`) for `insights-dashboard`, `insights-api`, `insights-db-migration`, and `insights-cronjob`
 * Pin `appVersion` to full semver (`18.3.30`) since GCR uses immutable tags — floating tags like `18.3` are only available on Quay

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.3.30"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 9.2.0
+version: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/templates/postgresql-auth.externalsecret.yaml
+++ b/stable/fairwinds-insights/templates/postgresql-auth.externalsecret.yaml
@@ -26,8 +26,7 @@ metadata:
     {{- include "fairwinds-insights.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "-10"
   {{- with $externalSecret.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/stable/fairwinds-insights/templates/postgresql-auth.externalsecret.yaml
+++ b/stable/fairwinds-insights/templates/postgresql-auth.externalsecret.yaml
@@ -24,8 +24,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "fairwinds-insights.labels" . | nindent 4 }}
-  {{- with $externalSecret.annotations }}
   annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+  {{- with $externalSecret.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
