### PR TITLE
[stable/insights-agent] INS-2413: Fixing cosign cache dir

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.7.1
+* Fixed image-trust keyless verification failing with read-only root filesystem by mounting a writable cosign/Sigstore cache directory
+
 ## 5.7.0
 * Added image-trust plugin
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.7.0
+version: 5.7.1
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/image-trust/_env.tpl
+++ b/stable/insights-agent/templates/image-trust/_env.tpl
@@ -1,10 +1,8 @@
 {{- define "image-trust-env" -}}
 {{- $cfg := index .Values "image-trust" -}}
 {{- $effectiveModes := include "image-trust.effectiveModes" . -}}
-{{- if eq (include "image-trust.needsCosignCache" .) "true" }}
 - name: HOME
   value: "/home/image-trust"
-{{- end }}
 {{- if $effectiveModes }}
 - name: IMAGE_TRUST_MODES
   value: {{ $effectiveModes | quote }}

--- a/stable/insights-agent/templates/image-trust/_env.tpl
+++ b/stable/insights-agent/templates/image-trust/_env.tpl
@@ -1,6 +1,10 @@
 {{- define "image-trust-env" -}}
 {{- $cfg := index .Values "image-trust" -}}
 {{- $effectiveModes := include "image-trust.effectiveModes" . -}}
+{{- if eq (include "image-trust.needsCosignCache" .) "true" }}
+- name: HOME
+  value: "/home/image-trust"
+{{- end }}
 {{- if $effectiveModes }}
 - name: IMAGE_TRUST_MODES
   value: {{ $effectiveModes | quote }}

--- a/stable/insights-agent/templates/image-trust/_helpers.tpl
+++ b/stable/insights-agent/templates/image-trust/_helpers.tpl
@@ -19,20 +19,6 @@ True when attestations.enabled or at least one attestation type is configured.
 {{- end -}}
 
 {{/*
-True when cosign needs a writable home directory for Sigstore TUF/Rekor cache (readOnlyRootFilesystem).
-*/}}
-{{- define "image-trust.needsCosignCache" -}}
-{{- $cfg := index .Values "image-trust" -}}
-{{- $modesStr := include "image-trust.effectiveModes" . | trim -}}
-{{- if $modesStr -}}
-{{- $modes := splitList "," $modesStr -}}
-{{- $hasKeyless := or (has "cosign-keyless" $modes) (has "cosign-attestation-keyless" $modes) -}}
-{{- $hasKeyedRekor := and (or (has "cosign-key" $modes) (has "cosign-attestation-key" $modes)) (not $cfg.ignoreTlog) -}}
-{{- if or $hasKeyless $hasKeyedRekor -}}true{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Effective IMAGE_TRUST_MODES: base modes plus attestation modes when attestations are active.
 */}}
 {{- define "image-trust.effectiveModes" -}}

--- a/stable/insights-agent/templates/image-trust/_helpers.tpl
+++ b/stable/insights-agent/templates/image-trust/_helpers.tpl
@@ -19,6 +19,20 @@ True when attestations.enabled or at least one attestation type is configured.
 {{- end -}}
 
 {{/*
+True when cosign needs a writable home directory for Sigstore TUF/Rekor cache (readOnlyRootFilesystem).
+*/}}
+{{- define "image-trust.needsCosignCache" -}}
+{{- $cfg := index .Values "image-trust" -}}
+{{- $modesStr := include "image-trust.effectiveModes" . | trim -}}
+{{- if $modesStr -}}
+{{- $modes := splitList "," $modesStr -}}
+{{- $hasKeyless := or (has "cosign-keyless" $modes) (has "cosign-attestation-keyless" $modes) -}}
+{{- $hasKeyedRekor := and (or (has "cosign-key" $modes) (has "cosign-attestation-key" $modes)) (not $cfg.ignoreTlog) -}}
+{{- if or $hasKeyless $hasKeyedRekor -}}true{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Effective IMAGE_TRUST_MODES: base modes plus attestation modes when attestations are active.
 */}}
 {{- define "image-trust.effectiveModes" -}}

--- a/stable/insights-agent/templates/image-trust/cronjob.yaml
+++ b/stable/insights-agent/templates/image-trust/cronjob.yaml
@@ -54,10 +54,8 @@ spec:
             secret:
               secretName: {{ $cfg.registryCertDirsFile.secret }}
           {{- end }}
-          {{- if eq (include "image-trust.needsCosignCache" .) "true" }}
           - name: image-trust-cosign-cache
             emptyDir: {}
-          {{- end }}
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
             {{- if $cfg.publicKeys.secretName }}
@@ -100,10 +98,8 @@ spec:
               mountPath: /etc/image-trust/certs
               readOnly: true
             {{- end }}
-            {{- if eq (include "image-trust.needsCosignCache" .) "true" }}
             - name: image-trust-cosign-cache
               mountPath: /home/image-trust
-            {{- end }}
             command:
               - "./report.sh"
             env:

--- a/stable/insights-agent/templates/image-trust/cronjob.yaml
+++ b/stable/insights-agent/templates/image-trust/cronjob.yaml
@@ -54,6 +54,10 @@ spec:
             secret:
               secretName: {{ $cfg.registryCertDirsFile.secret }}
           {{- end }}
+          {{- if eq (include "image-trust.needsCosignCache" .) "true" }}
+          - name: image-trust-cosign-cache
+            emptyDir: {}
+          {{- end }}
           containers:
           - {{ include "container-spec" . | indent 12 | trim }}
             {{- if $cfg.publicKeys.secretName }}
@@ -95,6 +99,10 @@ spec:
             - name: image-trust-registry-cert-dirs-file
               mountPath: /etc/image-trust/certs
               readOnly: true
+            {{- end }}
+            {{- if eq (include "image-trust.needsCosignCache" .) "true" }}
+            - name: image-trust-cosign-cache
+              mountPath: /home/image-trust
             {{- end }}
             command:
               - "./report.sh"


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
