### PR TITLE
[stable/insights-agent] Insights agent use chart lock instead of requirements

### DIFF
--- a/stable/insights-agent/.gitignore
+++ b/stable/insights-agent/.gitignore
@@ -1,2 +1,1 @@
 charts/
-requirements.lock

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.7.2
+* Moved dependencies from `requirements.yaml` to `Chart.yaml`
+
 ## 5.7.1
 * Fixed image-trust keyless verification failing with read-only root filesystem by mounting a writable cosign/Sigstore cache directory
 

--- a/stable/insights-agent/Chart.lock
+++ b/stable/insights-agent/Chart.lock
@@ -1,37 +1,27 @@
 dependencies:
 - name: goldilocks
   repository: https://charts.fairwinds.com/stable
-  version: '10.3.*'
-  condition: goldilocks.enabled
+  version: 10.3.0
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: '28.14.*'
-  condition: prometheus-metrics.installPrometheusServer
+  version: 28.14.1
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable
-  version: '1.11.*'
-  condition: admission.enabled
+  version: 1.11.2
 - name: falco
   repository: https://falcosecurity.github.io/charts
-  version: '8.0.*'
-  condition: falco.installFalco
-  alias: falcosecurity
+  version: 8.0.5
 - name: vpa
-  version: '4.10.*'
   repository: https://charts.fairwinds.com/stable
-  condition: right-sizer.enableClosedBeta
-  alias: right-sizer-vpa
+  version: 4.10.2
 - name: trivy
-  version: 0.21.3
   repository: https://aquasecurity.github.io/helm-charts/
-  condition: trivy.server.installTrivyServer
-  alias: trivy-server
+  version: 0.21.3
 - name: dcgm-exporter
-  version: '4.8.1'
   repository: https://nvidia.github.io/dcgm-exporter/helm-charts
-  condition: dcgm-exporter.enabled
+  version: 4.8.1
 - name: device-metrics-exporter-charts
-  version: '1.4.1'
   repository: https://rocm.github.io/device-metrics-exporter
-  condition: amd-device-metrics-exporter.enabled
-  alias: amd-device-metrics-exporter
+  version: v1.4.1
+digest: sha256:d3a6a71687cd52597e2024c7b473c1c86a1df984d462fb878d389ede2fb32327
+generated: "2026-06-05T09:56:47.993355-03:00"

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
 version: 5.7.1
@@ -8,3 +8,40 @@ icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insigh
 maintainers:
   - name: vitorvezani
   - name: jdesouza
+dependencies:
+  - name: goldilocks
+    repository: https://charts.fairwinds.com/stable
+    version: '10.3.*'
+    condition: goldilocks.enabled
+  - name: prometheus
+    repository: https://prometheus-community.github.io/helm-charts
+    version: '28.14.*'
+    condition: prometheus-metrics.installPrometheusServer
+  - name: insights-admission
+    repository: https://charts.fairwinds.com/stable
+    version: '1.11.*'
+    condition: admission.enabled
+  - name: falco
+    repository: https://falcosecurity.github.io/charts
+    version: '8.0.*'
+    condition: falco.installFalco
+    alias: falcosecurity
+  - name: vpa
+    version: '4.10.*'
+    repository: https://charts.fairwinds.com/stable
+    condition: right-sizer.enableClosedBeta
+    alias: right-sizer-vpa
+  - name: trivy
+    version: 0.21.3
+    repository: https://aquasecurity.github.io/helm-charts/
+    condition: trivy.server.installTrivyServer
+    alias: trivy-server
+  - name: dcgm-exporter
+    version: '4.8.1'
+    repository: https://nvidia.github.io/dcgm-exporter/helm-charts
+    condition: dcgm-exporter.enabled
+  - name: device-metrics-exporter-charts
+    version: '1.4.1'
+    repository: https://rocm.github.io/device-metrics-exporter
+    condition: amd-device-metrics-exporter.enabled
+    alias: amd-device-metrics-exporter

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.7.1
+version: 5.7.2
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png


### PR DESCRIPTION
**Why This PR?**
* Moved dependencies from `requirements.yaml` to `Chart.yaml`

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
