### PR TITLE
[stable/fairwinds-insights] Remove chart lock file from gitignore

### DIFF
--- a/stable/fairwinds-insights/.gitignore
+++ b/stable/fairwinds-insights/.gitignore
@@ -1,2 +1,1 @@
 charts/
-Chart.lock

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.3.2
+* Remove `Chart.lock` from `.gitignore`
+
 ## 9.3.1
 * Increase `delete-org-cluster-worker` default value for `POSTGRES_MAX_OPEN_CONNS` from `2` to `4` 
 

--- a/stable/fairwinds-insights/Chart.lock
+++ b/stable/fairwinds-insights/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: rustfs
+  repository: https://charts.rustfs.com/
+  version: 0.0.93
+- name: temporal
+  repository: https://go.temporal.io/helm-charts
+  version: 1.2.0
+digest: sha256:f9c02c6a65baf41b32e2ff3ac3bf5eeb59c96ed999a0f40833e04ad821566726
+generated: "2026-06-05T10:08:53.535107-03:00"

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.3.30"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 9.3.1
+version: 9.3.2
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren


### PR DESCRIPTION
**Why This PR?**
* Remove chart lock file from gitignore

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
