### PR TITLE
Add renovate to manage stable charts dependencies versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,7 @@
       "groupName": "CircleCI major updates"
     },
     {
-      "description": "Bump chart version on dependency and image updates (top-level version: only)",
+      "description": "Bump chart version on dependency and image updates",
       "matchManagers": ["helmv3", "helm-values"],
       "matchFileNames": ["stable/**"],
       "bumpVersions": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":dependencyDashboard"],
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 10,
+  "branchConcurrentLimit": 10,
+  "minimumReleaseAge": "7 days",
+  "ignorePaths": ["incubator/**", "docs/**"],
+  "registryAliases": {
+    "stable": "https://charts.fairwinds.com/stable"
+  },
+  "enabledManagers": ["helmv3", "helm-values", "circleci"],
+  "packageRules": [
+    {
+      "description": "Resolve @stable Helm repo alias and explicit fairwinds-stable URLs to the published index",
+      "matchManagers": ["helmv3"],
+      "matchDatasources": ["helm"],
+      "matchSourceUrls": [
+        "https://charts.fairwinds.com/stable",
+        "https://charts.fairwinds.com/stable/"
+      ],
+      "registryUrls": ["https://charts.fairwinds.com/stable"]
+    },
+    {
+      "matchManagers": ["helmv3"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "Helm chart major updates"
+    },
+    {
+      "matchManagers": ["helm-values"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "Helm values non-major updates"
+    },
+    {
+      "matchManagers": ["helm-values"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "Helm values major updates"
+    },
+    {
+      "matchManagers": ["circleci"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "CircleCI non-major updates"
+    },
+    {
+      "matchManagers": ["circleci"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "CircleCI major updates"
+    },
+    {
+      "description": "Every upgrade: upstream release must be at least 7 days old",
+      "matchManagers": ["helmv3", "helm-values", "circleci"],
+      "minimumReleaseAge": "7 days"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,18 @@
       "groupName": "CircleCI major updates"
     },
     {
+      "description": "Bump chart version on dependency and image updates (top-level version: only)",
+      "matchManagers": ["helmv3", "helm-values"],
+      "matchFileNames": ["stable/**"],
+      "bumpVersions": [
+        {
+          "filePatterns": ["{{packageFileDir}}/Chart.{yaml,yml}"],
+          "matchStrings": ["(?m)^version:\\s(?<version>[^\\s]+)"],
+          "bumpType": "{{#if isPatch}}patch{{else}}minor{{/if}}"
+        }
+      ]
+    },
+    {
       "description": "Every upgrade: upstream release must be at least 7 days old",
       "matchManagers": ["helmv3", "helm-values", "circleci"],
       "minimumReleaseAge": "7 days"


### PR DESCRIPTION
**Why This PR?**
* Add Renovate to manage stable chart dependencies versions
* We still have to follow up with a process to update `CHANGELOG.MD`

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
