### PR TITLE
[stable/fairwinds-insights] Preventing password and TLS CA regeneration on blank values

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.5.6
+* Ephemeral PostgreSQL and Timescale pre-install Secrets no longer regenerate passwords or TLS CA material on every `helm upgrade` when values are left blank
+
 ## 9.5.5
 * Support dynamic deployment name for cnpg-operator
 * Add `helm.sh/resource-policy: keep` to timescale secrets

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.3.30"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 9.5.5
+version: 9.5.6
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/templates/_helpers.tpl
+++ b/stable/fairwinds-insights/templates/_helpers.tpl
@@ -153,6 +153,25 @@ true
 {{- end -}}
 {{- end -}}
 
+{{- define "fairwinds-insights.ephemeralSecretPassword" -}}
+{{- $root := .root -}}
+{{- $value := .value -}}
+{{- $secretName := .secretName -}}
+{{- $key := .key | default "password" -}}
+{{- if $value -}}
+{{- $value -}}
+{{- else if $secretName -}}
+{{- $existing := lookup "v1" "Secret" $root.Release.Namespace $secretName -}}
+{{- if and $existing (index $existing.data $key) -}}
+{{- index $existing.data $key | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 32 -}}
+{{- end -}}
+{{- else -}}
+{{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Unquoted PostgreSQL identifiers only (used in CNPG postInitSQL).
 */}}

--- a/stable/fairwinds-insights/templates/secret.yml
+++ b/stable/fairwinds-insights/templates/secret.yml
@@ -13,8 +13,15 @@ type: Opaque
 {{- end }}
 ---
 {{- if .Values.postgresql.ephemeral }}
-{{- $password := default (randAlphaNum 32) .Values.postgresql.auth.password }}
-{{- $migrationPassword := default $password .Values.postgresql.auth.migrationPassword }}
+{{- $password := include "fairwinds-insights.ephemeralSecretPassword" (dict "root" . "value" .Values.postgresql.auth.password "secretName" .Values.postgresql.auth.existingSecret "key" "password") }}
+{{- $migrationPassword := .Values.postgresql.auth.migrationPassword }}
+{{- if not $migrationPassword }}
+{{- if eq (include "fairwinds-insights.postgresqlSplitAppMigration" .) "true" }}
+{{- $migrationPassword = include "fairwinds-insights.ephemeralSecretPassword" (dict "root" . "value" "" "secretName" (include "fairwinds-insights.postgresqlMigrationSecret" .) "key" "password") }}
+{{- else }}
+{{- $migrationPassword = $password }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 data:
     password: {{ b64enc $password }}
@@ -46,7 +53,7 @@ type: Opaque
 apiVersion: v1
 data:
     username: {{ b64enc "postgres" }}
-    password: {{ b64enc (default (randAlphaNum 32) .Values.postgresql.auth.superuserpassword) }}
+    password: {{ b64enc (include "fairwinds-insights.ephemeralSecretPassword" (dict "root" . "value" .Values.postgresql.auth.superuserpassword "secretName" .Values.postgresql.auth.existingSuperUserSecret "key" "password")) }}
 kind: Secret
 metadata:
   name: {{ .Values.postgresql.auth.existingSuperUserSecret }}
@@ -57,8 +64,15 @@ type: Opaque
 {{- end }}
 ---
 {{- if .Values.timescale.ephemeral }}
-{{- $tsPassword := default (randAlphaNum 32) .Values.timescale.password }}
-{{- $tsMigrationPassword := default $tsPassword .Values.timescale.auth.migrationPassword }}
+{{- $tsPassword := include "fairwinds-insights.ephemeralSecretPassword" (dict "root" . "value" .Values.timescale.password "secretName" .Values.timescale.auth.existingSecret "key" "password") }}
+{{- $tsMigrationPassword := .Values.timescale.auth.migrationPassword }}
+{{- if not $tsMigrationPassword }}
+{{- if eq (include "fairwinds-insights.timescaleSplitAppMigration" .) "true" }}
+{{- $tsMigrationPassword = include "fairwinds-insights.ephemeralSecretPassword" (dict "root" . "value" "" "secretName" (include "fairwinds-insights.timescaleMigrationSecret" .) "key" "password") }}
+{{- else }}
+{{- $tsMigrationPassword = $tsPassword }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 data:
     password: {{ b64enc $tsPassword }}
@@ -92,7 +106,7 @@ type: Opaque
 apiVersion: v1
 data:
     username: {{ b64enc "postgres" }}
-    password: {{ b64enc (default (randAlphaNum 32) .Values.timescale.superuserpassword) }}
+    password: {{ b64enc (include "fairwinds-insights.ephemeralSecretPassword" (dict "root" . "value" .Values.timescale.superuserpassword "secretName" .Values.timescale.auth.existingSuperUserSecret "key" "password")) }}
 kind: Secret
 metadata:
   name: {{ .Values.timescale.auth.existingSuperUserSecret }}
@@ -103,32 +117,48 @@ type: Opaque
 {{- end }}
 ---
 {{- if .Values.timescale.ephemeral }}
+{{- $timescaleCASecretName := "fwinsights-timescale-ca" }}
+{{- $existingTimescaleCA := lookup "v1" "Secret" .Release.Namespace $timescaleCASecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: fwinsights-timescale-ca
+  name: {{ $timescaleCASecretName }}
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "-1"
 type: kubernetes.io/tls
+{{- if and $existingTimescaleCA $existingTimescaleCA.data (index $existingTimescaleCA.data "tls.crt") (index $existingTimescaleCA.data "tls.key") }}
+data:
+  tls.crt: {{ index $existingTimescaleCA.data "tls.crt" }}
+  tls.key: {{ index $existingTimescaleCA.data "tls.key" }}
+{{- else }}
 {{ $ca := genCA "timescale" 1826 -}}
 stringData:
     tls.crt: {{ $ca.Cert | quote }}
     tls.key: {{ $ca.Key  | quote }}
 {{- end }}
+{{- end }}
 ---
 {{- if .Values.postgresql.ephemeral }}
+{{- $postgresqlCASecretName := "fwinsights-postgresql-ca" }}
+{{- $existingPostgresqlCA := lookup "v1" "Secret" .Release.Namespace $postgresqlCASecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: fwinsights-postgresql-ca
+  name: {{ $postgresqlCASecretName }}
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "-1"
 type: kubernetes.io/tls
+{{- if and $existingPostgresqlCA $existingPostgresqlCA.data (index $existingPostgresqlCA.data "tls.crt") (index $existingPostgresqlCA.data "tls.key") }}
+data:
+  tls.crt: {{ index $existingPostgresqlCA.data "tls.crt" }}
+  tls.key: {{ index $existingPostgresqlCA.data "tls.key" }}
+{{- else }}
 {{ $ca := genCA "postgres" 1826 -}}
 stringData:
     tls.crt: {{ $ca.Cert | quote }}
     tls.key: {{ $ca.Key  | quote }}
+{{- end }}
 {{- end }}
 ---


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
