### PR TITLE
[stable/fairwinds-insights] Move CloudNativePG operator settings from postgresql.operator to top level cnpg

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.6.0
+* **Backward compatible:** Move CloudNativePG operator settings from `postgresql.operator` to top-level `cnpg`. Use `cnpg.install` when provisioning ephemeral Timescale/PostgreSQL. `postgresql.operator` is still honored if set but deprecated.
+
 ## 9.5.6
 * Ephemeral PostgreSQL and Timescale pre-install Secrets no longer regenerate passwords or TLS CA material on every `helm upgrade` when values are left blank
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.3.30"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 9.5.6
+version: 9.6.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -186,16 +186,18 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | ingress.starPaths | bool | `true` | Certain ingress controllers do pattern matches, others use prefixes. If `/*` doesn't work for your ingress, try setting this to false. |
 | ingress.separate | bool | `false` | Create different Ingress objects for the API and dashboard - this allows them to have different annotations |
 | ingress.extraPaths | object | `{}` | Adds additional path ie. Redirect path for ALB |
+| cnpg.install | bool | `true` | Install CloudNativePG operator (used by ephemeral PostgreSQL and/or Timescale) |
+| cnpg.version | string | `"1.28.1"` | CloudNativePG operator version to install |
+| cnpg.defaultVersion | string | `"1.28.1"` | Fallback CloudNativePG operator version when version is "latest" but resolution from GitHub fails |
+| cnpg.webhook | object | `{"mutating":{"create":true},"validating":{"create":true}}` | CloudNativePG operator configuration |
+| cnpg.crds.create | bool | `true` |  |
+| cnpg.clusterReadyTimeoutSeconds | int | `600` |  |
 | postgresql.postMigrate | bool | `false` | Set to `true` to run migrations after the install, upgrade |
 | postgresql.image.registry | string | `"quay.io"` |  |
 | postgresql.image.repository | string | `"fairwinds/postgres-partman"` |  |
 | postgresql.image.tag | string | `"17.0"` |  |
 | postgresql.ephemeral | bool | `true` | Use the ephemeral postgresql cluster by default |
 | postgresql.enablePDB | bool | `true` | Let CloudNativePG manage PodDisruptionBudgets for the PostgreSQL cluster |
-| postgresql.operator | object | `{"clusterReadyTimeoutSeconds":600,"crds":{"create":true},"defaultVersion":"1.28.1","install":true,"version":"1.28.1","webhook":{"mutating":{"create":true},"validating":{"create":true}}}` | Install CloudNativePG operator |
-| postgresql.operator.version | string | `"1.28.1"` | CloudNativePG operator version to install |
-| postgresql.operator.defaultVersion | string | `"1.28.1"` | Fallback CloudNativePG operator version when version is "latest" but resolution from GitHub fails |
-| postgresql.operator.webhook | object | `{"mutating":{"create":true},"validating":{"create":true}}` | CloudNativePG operator configuration |
 | postgresql.sslMode | string | `"require"` | SSL mode for connecting to the database |
 | postgresql.tls | object | `{"certFilename":"tls.crt","certKeyFilename":"tls.key","certificatesSecret":"fwinsights-postgresql-ca","enabled":true}` | TLS mode for connecting to the database |
 | postgresql.postgresqlHost | string | `"insights-postgres-rw"` | Host for postgresql (CloudNativePG cluster name) |

--- a/stable/fairwinds-insights/ci/test-values.yaml
+++ b/stable/fairwinds-insights/ci/test-values.yaml
@@ -17,12 +17,12 @@ deployments:
   additionalPodLabels:
     pod-foo: pod-bar
 
+cnpg:
+  install: true
+
 postgresql:
   # Enable ephemeral PostgreSQL cluster
   ephemeral: true
-  # Install CloudNativePG operator
-  operator:
-    install: true
   # Storage configuration
   storage:
     size: 5Gi

--- a/stable/fairwinds-insights/templates/_helpers.tpl
+++ b/stable/fairwinds-insights/templates/_helpers.tpl
@@ -172,6 +172,13 @@ true
 {{- end -}}
 {{- end -}}
 
+{{/* Resolved CloudNativePG operator values. `cnpg` is primary; `postgresql.operator` is deprecated. */}}
+{{- define "fairwinds-insights.cnpg" -}}
+{{- $legacy := default dict .Values.postgresql.operator -}}
+{{- $cnpg := default dict .Values.cnpg -}}
+{{- mergeOverwrite $legacy $cnpg | toYaml -}}
+{{- end -}}
+
 {{/*
 Unquoted PostgreSQL identifiers only (used in CNPG postInitSQL).
 */}}

--- a/stable/fairwinds-insights/templates/postgresql-cluster.yaml
+++ b/stable/fairwinds-insights/templates/postgresql-cluster.yaml
@@ -1,4 +1,5 @@
-{{- $cnpgOperatorJob := and .Values.postgresql.operator.install (or .Values.postgresql.ephemeral .Values.timescale.ephemeral) }}
+{{- $cnpg := include "fairwinds-insights.cnpg" . | fromYaml -}}
+{{- $cnpgOperatorJob := and $cnpg.install (or .Values.postgresql.ephemeral .Values.timescale.ephemeral) }}
 {{- if $cnpgOperatorJob }}
 ---
 # Minimal RBAC for PostgreSQL / Timescale cluster creation
@@ -116,7 +117,7 @@ spec:
             echo "Namespace: {{ .Release.Namespace }}"
             echo "Release: {{ .Release.Name }}"
 
-            OPERATOR_NAMESPACE="{{ .Values.postgresql.operator.namespace }}"
+            OPERATOR_NAMESPACE="{{ $cnpg.namespace }}"
             if [ -z "$OPERATOR_NAMESPACE" ]; then
               OPERATOR_NAMESPACE="cnpg-system"
             fi
@@ -134,8 +135,8 @@ spec:
                   kubectl create namespace "$OPERATOR_NAMESPACE"
                 fi
 
-                OPERATOR_VERSION="{{ .Values.postgresql.operator.version }}"
-                DEFAULT_CNPG_VERSION="{{ .Values.postgresql.operator.defaultVersion | default "1.28.1" }}"
+                OPERATOR_VERSION="{{ $cnpg.version }}"
+                DEFAULT_CNPG_VERSION="{{ $cnpg.defaultVersion | default "1.28.1" }}"
                 if [ "$OPERATOR_VERSION" = "latest" ]; then
                   echo "Resolving latest CloudNativePG operator version..."
                   CNPG_VERSION=""
@@ -214,7 +215,7 @@ spec:
             fi
             {{- end }}
 
-            READY_TIMEOUT="{{ .Values.postgresql.operator.clusterReadyTimeoutSeconds | default 600 }}s"
+            READY_TIMEOUT="{{ $cnpg.clusterReadyTimeoutSeconds | default 600 }}s"
             NS="{{ .Release.Namespace }}"
             describe_on_fail() {
               echo "--- kubectl describe cluster/$1 (last status) ---"
@@ -253,11 +254,11 @@ spec:
             drop:
               - ALL
 {{- end }}
-{{- if and .Values.postgresql.ephemeral (not .Values.postgresql.operator.install) }}
+{{- if and .Values.postgresql.ephemeral (not $cnpg.install) }}
 ---
 {{ include "fairwinds-insights.cnpg.postgresCluster" (dict "root" . "mode" "helm") }}
 {{- end }}
-{{- if and .Values.timescale.ephemeral (not .Values.postgresql.operator.install) }}
+{{- if and .Values.timescale.ephemeral (not $cnpg.install) }}
 ---
 {{ include "fairwinds-insights.cnpg.timescaleClusterImageCatalog" (dict "root" . "mode" "helm") }}
 ---

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -632,6 +632,24 @@ ingress:
   # -- Adds additional path ie. Redirect path for ALB
   extraPaths: {}
 
+cnpg:
+  # -- Install CloudNativePG operator (used by ephemeral PostgreSQL and/or Timescale)
+  install: true
+  # -- CloudNativePG operator version to install
+  version: "1.28.1"
+  # -- Fallback CloudNativePG operator version when version is "latest" but resolution from GitHub fails
+  defaultVersion: "1.28.1"
+  # -- CloudNativePG operator configuration
+  webhook:
+    mutating:
+      create: true
+    validating:
+      create: true
+  crds:
+    create: true
+  # -- Per-cluster timeout for `kubectl wait --for=condition=Ready` on each CNPG Cluster in the pre-install hook (PostgreSQL and Timescale when ephemeral). Keeps the hook from finishing before both databases accept connections.
+  clusterReadyTimeoutSeconds: 600
+
 postgresql:
   # -- Set to `true` to run migrations after the install, upgrade
   postMigrate: false
@@ -643,23 +661,6 @@ postgresql:
   ephemeral: true
   # -- Let CloudNativePG manage PodDisruptionBudgets for the PostgreSQL cluster
   enablePDB: true
-  # -- Install CloudNativePG operator
-  operator:
-    install: true
-    # -- CloudNativePG operator version to install
-    version: "1.28.1"
-    # -- Fallback CloudNativePG operator version when version is "latest" but resolution from GitHub fails
-    defaultVersion: "1.28.1"
-    # -- CloudNativePG operator configuration
-    webhook:
-      mutating:
-        create: true
-      validating:
-        create: true
-    crds:
-      create: true
-    # -- Per-cluster timeout for `kubectl wait --for=condition=Ready` on each CNPG Cluster in the pre-install hook (PostgreSQL and Timescale when ephemeral). Keeps the hook from finishing before both databases accept connections.
-    clusterReadyTimeoutSeconds: 600
   # -- SSL mode for connecting to the database
   sslMode: require
   # -- TLS mode for connecting to the database


### PR DESCRIPTION
**Why This PR?**
Move CloudNativePG operator settings from postgresql.operator to top level cnpg

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
