### PR TITLE
[stable/fairwinds-insights] Fix gRPC ingress ALB annotation merge order and derive a separate ingress group

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.9.3
+* Fix gRPC ingress ALB annotation merge order and derive a separate ingress group when the main ingress uses `alb.ingress.kubernetes.io/group.name`.
+
 ## 9.9.2
 * Bump dependencies
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.3.56"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 9.9.2
+version: 9.9.3
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -90,7 +90,8 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | api.grpc.networkFlow.batchSize | string | `""` | Batch size for network flow gRPC ingestion. |
 | api.grpc.ingress.enabled | bool | `false` | Create a dedicated ALB Ingress for the network-flow gRPC server. |
 | api.grpc.ingress.hostname | string | `""` | Public hostname for gRPC Ingress. Defaults to grpc-{sanitizedBranch}.{first hostedZone} or grpc.{first hostedZone}. |
-| api.grpc.ingress.annotations | object | `{}` | Additional annotations merged on top of ingress.annotations. |
+| api.grpc.ingress.groupName | string | `""` | ALB ingress group for the gRPC Ingress. Defaults to {ingress.annotations group.name}-grpc when the main ingress uses a shared group. |
+| api.grpc.ingress.annotations | object | `{}` | Additional annotations merged last (after ingress.annotations and gRPC defaults). |
 | api.pdb.enabled | bool | `false` | Create a pod disruption budget for the API server. |
 | api.pdb.minReplicas | int | `1` | How many replicas should always exist for the API server. |
 | api.hpa.enabled | bool | `false` | Create a horizontal pod autoscaler for the API server. |

--- a/stable/fairwinds-insights/templates/_helpers.tpl
+++ b/stable/fairwinds-insights/templates/_helpers.tpl
@@ -63,6 +63,14 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 {{- end -}}
 
+{{- define "fairwinds-insights.api.grpcIngressGroupName" -}}
+{{- if .Values.api.grpc.ingress.groupName -}}
+{{- .Values.api.grpc.ingress.groupName -}}
+{{- else if index .Values.ingress.annotations "alb.ingress.kubernetes.io/group.name" -}}
+{{- printf "%s-grpc" (index .Values.ingress.annotations "alb.ingress.kubernetes.io/group.name") -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "fairwinds-insights.cronjobImageTag" -}}
 {{- if .Values.cronjobImage.tag -}}
 {{- .Values.cronjobImage.tag -}}

--- a/stable/fairwinds-insights/templates/ingress-grpc.yaml
+++ b/stable/fairwinds-insights/templates/ingress-grpc.yaml
@@ -1,6 +1,7 @@
 {{- if and .Values.api.grpc.enabled .Values.api.grpc.ingress.enabled .Values.ingress.enabled }}
 {{- $fullName := include "fairwinds-insights.fullname" . -}}
 {{- $hostname := include "fairwinds-insights.api.grpcIngressHostname" . -}}
+{{- $ingressAnnotations := omit .Values.ingress.annotations "alb.ingress.kubernetes.io/group.name" "alb.ingress.kubernetes.io/healthcheck-path" "alb.ingress.kubernetes.io/healthcheck-port" "alb.ingress.kubernetes.io/backend-protocol-version" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -8,11 +9,14 @@ metadata:
   labels:
     {{- include "fairwinds-insights.labels" . | nindent 4 }}
   annotations:
+    {{- with $ingressAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     alb.ingress.kubernetes.io/backend-protocol-version: GRPC
     alb.ingress.kubernetes.io/healthcheck-port: "8080"
     alb.ingress.kubernetes.io/healthcheck-path: /readyz
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- with include "fairwinds-insights.api.grpcIngressGroupName" . }}
+    alb.ingress.kubernetes.io/group.name: {{ . | quote }}
     {{- end }}
     {{- with .Values.api.grpc.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -305,7 +305,9 @@ api:
       enabled: false
       # -- Public hostname for gRPC Ingress. Defaults to grpc-{sanitizedBranch}.{first hostedZone} or grpc.{first hostedZone}.
       hostname: ""
-      # -- Additional annotations merged on top of ingress.annotations.
+      # -- ALB ingress group for the gRPC Ingress. Defaults to {ingress.annotations group.name}-grpc when the main ingress uses a shared group.
+      groupName: ""
+      # -- Additional annotations merged last (after ingress.annotations and gRPC defaults).
       annotations: {}
   pdb:
     # -- Create a pod disruption budget for the API server.


### PR DESCRIPTION
…ress group

**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
