### PR TITLE
[stable/fairwinds-insights] changing the default value of appGroupHealthForReportWorkflowEnabled default

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 9.9.4
 * Change `appGroupHealthForReportWorkflowEnabled` default from `false` to `true`
+* Set `alb.ingress.kubernetes.io/target-type: ip` on the gRPC Ingress so it works when the API Service is `ClusterIP`.
+* Set explicit HTTP health check annotations on the gRPC Ingress (`healthcheck-protocol: HTTP`, `success-codes: "200"`).
 
 ## 9.9.3
 * Fix gRPC ingress ALB annotation merge order and derive a separate ingress group when the main ingress uses `alb.ingress.kubernetes.io/group.name`.

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.9.4
+* Change `appGroupHealthForReportWorkflowEnabled` default from `false` to `true`
+
 ## 9.9.3
 * Fix gRPC ingress ALB annotation merge order and derive a separate ingress group when the main ingress uses `alb.ingress.kubernetes.io/group.name`.
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.3.56"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 9.9.3
+version: 9.9.4
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -339,7 +339,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | reportjob.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"reportjob"` |  |
 | reportjob.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
 | reportjob.terminationGracePeriodSeconds | int | `600` |  |
-| reportjob.appGroupHealthForReportWorkflowEnabled | bool | `false` |  |
+| reportjob.appGroupHealthForReportWorkflowEnabled | bool | `true` |  |
 | reportjob.additionalEnvVars | list | `[]` |  |
 | outboxWorker | object | `{"additionalEnvVars":[],"affinity":null,"annotations":{},"args":[],"command":["outbox_worker"],"enabled":true,"image":{"repository":"","tag":""},"imagePullPolicy":"Always","initContainers":[],"nodeSelector":{},"podAnnotations":{},"priorityClassName":"","replicas":1,"resources":{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324},"terminationGracePeriodSeconds":600,"tolerations":[],"topologySpreadConstraints":[],"useReadReplica":false,"volumeMounts":[],"volumes":[]}` | Deploy the outbox worker |
 | outboxWorker.enabled | bool | `true` | Enable the outbox-worker Deployment |

--- a/stable/fairwinds-insights/templates/ingress-grpc.yaml
+++ b/stable/fairwinds-insights/templates/ingress-grpc.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.api.grpc.enabled .Values.api.grpc.ingress.enabled .Values.ingress.enabled }}
 {{- $fullName := include "fairwinds-insights.fullname" . -}}
 {{- $hostname := include "fairwinds-insights.api.grpcIngressHostname" . -}}
-{{- $ingressAnnotations := omit .Values.ingress.annotations "alb.ingress.kubernetes.io/group.name" "alb.ingress.kubernetes.io/healthcheck-path" "alb.ingress.kubernetes.io/healthcheck-port" "alb.ingress.kubernetes.io/backend-protocol-version" -}}
+{{- $ingressAnnotations := omit .Values.ingress.annotations "alb.ingress.kubernetes.io/group.name" "alb.ingress.kubernetes.io/healthcheck-path" "alb.ingress.kubernetes.io/healthcheck-port" "alb.ingress.kubernetes.io/healthcheck-protocol" "alb.ingress.kubernetes.io/success-codes" "alb.ingress.kubernetes.io/backend-protocol-version" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -13,8 +13,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     alb.ingress.kubernetes.io/backend-protocol-version: GRPC
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
     alb.ingress.kubernetes.io/healthcheck-port: "8080"
     alb.ingress.kubernetes.io/healthcheck-path: /readyz
+    alb.ingress.kubernetes.io/success-codes: "200"
     {{- with include "fairwinds-insights.api.grpcIngressGroupName" . }}
     alb.ingress.kubernetes.io/group.name: {{ . | quote }}
     {{- end }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -1005,8 +1005,8 @@ reportjob:
           app.kubernetes.io/component: reportjob
           app.kubernetes.io/name: fairwinds-insights
   terminationGracePeriodSeconds: 600
-  # When true, sets ENABLE_APP_GROUP_HEALTH_FOR_REPORT_WORKFLOW on report_job so it enqueues the app-group health Temporal workflow after legacy cluster TS scores (requires general_worker).
-  appGroupHealthForReportWorkflowEnabled: false
+  # When true, enables the app-group health Temporal workflow after legacy cluster TS scores (requires general_worker).
+  appGroupHealthForReportWorkflowEnabled: true
   additionalEnvVars: []
 
 # -- Deploy the outbox worker


### PR DESCRIPTION

**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
