### PR TITLE
[stable/fairwinds-insights] Implement native gRPC ALB health checks on the gRPC Ingress

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.9.5
+* Use native gRPC ALB health checks on the gRPC Ingress. HTTP `/readyz` health checks are incompatible with GRPC target groups.
+
 ## 9.9.4
 * Change `appGroupHealthForReportWorkflowEnabled` default from `false` to `true`
 * Set `alb.ingress.kubernetes.io/target-type: ip` on the gRPC Ingress so it works when the API Service is `ClusterIP`.

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.3.56"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 9.9.4
+version: 9.9.5
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/templates/ingress-grpc.yaml
+++ b/stable/fairwinds-insights/templates/ingress-grpc.yaml
@@ -14,10 +14,9 @@ metadata:
     {{- end }}
     alb.ingress.kubernetes.io/backend-protocol-version: GRPC
     alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
-    alb.ingress.kubernetes.io/healthcheck-port: "8080"
-    alb.ingress.kubernetes.io/healthcheck-path: /readyz
-    alb.ingress.kubernetes.io/success-codes: "200"
+    alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+    alb.ingress.kubernetes.io/healthcheck-path: /grpc.health.v1.Health/Check
+    alb.ingress.kubernetes.io/success-codes: "0"
     {{- with include "fairwinds-insights.api.grpcIngressGroupName" . }}
     alb.ingress.kubernetes.io/group.name: {{ . | quote }}
     {{- end }}


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
