### PR TITLE
[stable/insights-agent] bump network-flow agent and aggregator to 0.0.6, and change their pullPolicy to Always

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.20.2
+* Bump network-flow agent and aggregator to `0.0.6` and change their pullPolicy to `Always`
+
 ## 5.20.1
 * Improve changelog versions bump documentation
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.20.1
+version: 5.20.2
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -1115,8 +1115,8 @@ network-observability:
   agent:
     image:
       repository: quay.io/fairwinds/network-flow
-      tag: "0.0.3"
-      pullPolicy: IfNotPresent
+      tag: "0.0.6"
+      pullPolicy: Always
     gadgetVersion: "v0.53.2"
     collectorAddr: ""
     batchSize: 5000
@@ -1164,8 +1164,8 @@ network-observability:
   aggregator:
     image:
       repository: quay.io/fairwinds/network-flow-aggregator
-      tag: "0.0.3"
-      pullPolicy: IfNotPresent
+      tag: "0.0.6"
+      pullPolicy: Always
     replicas: 1
     grpcPort: 4317
     httpPort: 8080


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
