### PR TITLE
[stable/fairwinds-insights] Replace `hostname` with `hosts` for supporting multiple hostnames

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.10.0
+* Replace `api.grpc.ingress.hostname` with `api.grpc.ingress.hosts` to support multiple gRPC Ingress hostnames.
+
 ## 9.9.6
 * Bump dependencies
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.3.58"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 9.9.6
+version: 9.10.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -89,7 +89,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | api.grpc.port | int | `4318` | Container and Service port for the network-flow gRPC server. |
 | api.grpc.networkFlow.batchSize | string | `""` | Batch size for network flow gRPC ingestion. |
 | api.grpc.ingress.enabled | bool | `false` | Create a dedicated ALB Ingress for the network-flow gRPC server. |
-| api.grpc.ingress.hostname | string | `""` | Public hostname for gRPC Ingress. Defaults to grpc-{sanitizedBranch}.{first hostedZone} or grpc.{first hostedZone}. |
+| api.grpc.ingress.hosts | list | `[]` | Public hostnames for gRPC Ingress. Defaults to grpc-{sanitizedBranch}.{first hostedZone} or grpc.{first hostedZone} when empty. |
 | api.grpc.ingress.groupName | string | `""` | ALB ingress group for the gRPC Ingress. Defaults to {ingress.annotations group.name}-grpc when the main ingress uses a shared group. |
 | api.grpc.ingress.annotations | object | `{}` | Additional annotations merged last (after ingress.annotations and gRPC defaults). |
 | api.pdb.enabled | bool | `false` | Create a pod disruption budget for the API server. |

--- a/stable/fairwinds-insights/templates/NOTES.txt
+++ b/stable/fairwinds-insights/templates/NOTES.txt
@@ -1,9 +1,14 @@
 {{ if gt (len .Values.ingress.hostedZones) 0 }}
 Fairwinds Insights is now running at https://{{ include "fairwinds-insights.sanitizedPrefix" . }}{{ index .Values.ingress.hostedZones 0 }}
-{{- if .Values.api.grpc.enabled }}
-Network flow gRPC (in-cluster): {{ include "fairwinds-insights.fullname" . }}-api.{{ .Release.Namespace }}.svc:{{ .Values.api.grpc.port }}
-{{- if and .Values.api.grpc.ingress.enabled .Values.ingress.enabled }}
-Network flow gRPC (public): https://{{ include "fairwinds-insights.api.grpcIngressHostname" . }}
+{{- if and .Values.api.grpc.enabled .Values.api.grpc.ingress.enabled .Values.ingress.enabled }}
+{{- $grpcHosts := .Values.api.grpc.ingress.hosts -}}
+{{- if not $grpcHosts -}}
+{{- with include "fairwinds-insights.api.grpcIngressHostname" . -}}
+{{- $grpcHosts = list . -}}
+{{- end -}}
+{{- end -}}
+{{- range $grpcHosts }}
+Fairwinds Insights (gRPC) is now running at https://{{ . }}
 {{- end }}
 {{- end }}
 {{ end }}

--- a/stable/fairwinds-insights/templates/_helpers.tpl
+++ b/stable/fairwinds-insights/templates/_helpers.tpl
@@ -50,9 +50,7 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{- define "fairwinds-insights.api.grpcIngressHostname" -}}
-{{- if .Values.api.grpc.ingress.hostname -}}
-{{- .Values.api.grpc.ingress.hostname -}}
-{{- else if gt (len .Values.ingress.hostedZones) 0 -}}
+{{- if gt (len .Values.ingress.hostedZones) 0 -}}
 {{- $zone := index .Values.ingress.hostedZones 0 -}}
 {{- if .Values.sanitizedBranch -}}
 {{- $branch := .Values.sanitizedBranch | trunc (int .Values.sanitizedPrefixMaxLength | default 12) | trimSuffix "-" -}}

--- a/stable/fairwinds-insights/templates/ingress-grpc.yaml
+++ b/stable/fairwinds-insights/templates/ingress-grpc.yaml
@@ -1,6 +1,12 @@
 {{- if and .Values.api.grpc.enabled .Values.api.grpc.ingress.enabled .Values.ingress.enabled }}
 {{- $fullName := include "fairwinds-insights.fullname" . -}}
-{{- $hostname := include "fairwinds-insights.api.grpcIngressHostname" . -}}
+{{- $hosts := .Values.api.grpc.ingress.hosts -}}
+{{- if not $hosts -}}
+{{- with include "fairwinds-insights.api.grpcIngressHostname" . -}}
+{{- $hosts = list . -}}
+{{- end -}}
+{{- end -}}
+{{- if $hosts }}
 {{- $ingressAnnotations := omit .Values.ingress.annotations "alb.ingress.kubernetes.io/group.name" "alb.ingress.kubernetes.io/healthcheck-path" "alb.ingress.kubernetes.io/healthcheck-port" "alb.ingress.kubernetes.io/healthcheck-protocol" "alb.ingress.kubernetes.io/success-codes" "alb.ingress.kubernetes.io/backend-protocol-version" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -31,10 +37,13 @@ spec:
   tls:
     - secretName: {{ $fullName }}-api-grpc-cert
       hosts:
-        - {{ $hostname }}
+        {{- range $hosts }}
+        - {{ . }}
+        {{- end }}
 {{- end }}
   rules:
-    - host: {{ $hostname }}
+    {{- range $hosts }}
+    - host: {{ . }}
       http:
         paths:
           - path: /
@@ -44,4 +53,6 @@ spec:
                 name: {{ $fullName }}-api
                 port:
                   name: grpc
+    {{- end }}
+{{- end }}
 {{- end }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -303,8 +303,8 @@ api:
     ingress:
       # -- Create a dedicated ALB Ingress for the network-flow gRPC server.
       enabled: false
-      # -- Public hostname for gRPC Ingress. Defaults to grpc-{sanitizedBranch}.{first hostedZone} or grpc.{first hostedZone}.
-      hostname: ""
+      # -- Public hostnames for gRPC Ingress. Defaults to grpc-{sanitizedBranch}.{first hostedZone} or grpc.{first hostedZone} when empty.
+      hosts: []
       # -- ALB ingress group for the gRPC Ingress. Defaults to {ingress.annotations group.name}-grpc when the main ingress uses a shared group.
       groupName: ""
       # -- Additional annotations merged last (after ingress.annotations and gRPC defaults).


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
