### PR TITLE
[stable/vpa]: adding extra env values

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 5.0.0
+version: 5.1.0
 appVersion: 1.7.1
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -206,6 +206,7 @@ For more information, see [VPA docs](https://github.com/kubernetes/autoscaler/bl
 | serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
 | recommender.enabled | bool | `true` | If true, the vpa recommender component will be installed. |
 | recommender.envFromSecret | string | `""` | Specify a secret to get environment variables from |
+| recommender.extraEnv | list | `[]` | Extra environment variables to add to the recommender container |
 | recommender.annotations | object | `{}` | Annotations to add to the recommender deployment |
 | recommender.extraArgs | object | `{"pod-recommendation-min-cpu-millicores":15,"pod-recommendation-min-memory-mb":100,"v":"4"}` | A set of key-value flags to be passed to the recommender |
 | recommender.replicaCount | int | `1` |  |
@@ -227,6 +228,7 @@ For more information, see [VPA docs](https://github.com/kubernetes/autoscaler/bl
 | recommender.podMonitor | object | `{"annotations":{},"enabled":false,"labels":{}}` | Enables a prometheus operator podMonitor for the recommender |
 | updater.enabled | bool | `true` | If true, the updater component will be deployed |
 | updater.annotations | object | `{}` | Annotations to add to the updater deployment |
+| updater.extraEnv | list | `[]` | Extra environment variables to add to the updater container |
 | updater.extraArgs | object | `{}` | A key-value map of flags to pass to the updater. Since VPA 1.6.0: set "in-place-skip-disruption-budget": "true" to skip PDB checks for in-place updates when all containers have NotRequired resize policy. |
 | updater.replicaCount | int | `1` |  |
 | updater.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
@@ -247,6 +249,7 @@ For more information, see [VPA docs](https://github.com/kubernetes/autoscaler/bl
 | updater.podMonitor | object | `{"annotations":{},"enabled":false,"labels":{}}` | Enables a prometheus operator podMonitor for the updater |
 | admissionController.enabled | bool | `true` | If true, will install the admission-controller component of vpa |
 | admissionController.annotations | object | `{}` | Annotations to add to the admission controller deployment |
+| admissionController.extraEnv | list | `[]` | Extra environment variables to add to the admission controller container |
 | admissionController.extraArgs | object | `{}` | A key-value map of flags to pass to the admissionController |
 | admissionController.generateCertificate | bool | `true` | If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook |
 | admissionController.secretName | string | `"{{ include \"vpa.fullname\" . }}-tls-secret"` | Name for the TLS secret created for the webhook. Default {{ .Release.Name }}-tls-secret |

--- a/stable/vpa/templates/admission-controller-deployment.yaml
+++ b/stable/vpa/templates/admission-controller-deployment.yaml
@@ -88,6 +88,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- with .Values.admissionController.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.admissionController.resources | nindent 12 }}
       hostNetwork: {{ .Values.admissionController.useHostNetwork | default false }}

--- a/stable/vpa/templates/recommender-deployment.yaml
+++ b/stable/vpa/templates/recommender-deployment.yaml
@@ -78,6 +78,10 @@ spec:
               name: {{ .Values.recommender.envFromSecret }}
           {{- end }}
           {{- end }}
+          {{- with .Values.recommender.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.recommender.resources | nindent 12 }}
       {{- with .Values.recommender.nodeSelector }}

--- a/stable/vpa/templates/updater-deployment.yaml
+++ b/stable/vpa/templates/updater-deployment.yaml
@@ -58,6 +58,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- with .Values.updater.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if .Values.updater.livenessProbe }}
           livenessProbe:
             {{- toYaml .Values.updater.livenessProbe | nindent 12 }}

--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -50,6 +50,8 @@ recommender:
   enabled: true
   # -- Specify a secret to get environment variables from
   envFromSecret: ""
+  # recommender.extraEnv -- Extra environment variables to add to the recommender container
+  extraEnv: []
   # recommender.annotations -- Annotations to add to the recommender deployment
   annotations: {}
   # recommender.extraArgs -- A set of key-value flags to be passed to the recommender
@@ -129,6 +131,8 @@ updater:
   enabled: true
   # updater.annotations -- Annotations to add to the updater deployment
   annotations: {}
+  # updater.extraEnv -- Extra environment variables to add to the updater container
+  extraEnv: []
   # updater.extraArgs -- A key-value map of flags to pass to the updater.
   # Since VPA 1.6.0: set "in-place-skip-disruption-budget": "true" to skip
   # PDB checks for in-place updates when all containers have NotRequired resize policy.
@@ -205,6 +209,8 @@ admissionController:
   enabled: true
   # admissionController.annotations -- Annotations to add to the admission controller deployment
   annotations: {}
+  # admissionController.extraEnv -- Extra environment variables to add to the admission controller container
+  extraEnv: []
   # admissionController.extraArgs -- A key-value map of flags to pass to the admissionController
   extraArgs: {}
   # admissionController.generateCertificate -- If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook


### PR DESCRIPTION
**Why This PR?**
Adding support to set extra env values. This could be everything from vpa specific to golang specific environment variables

Fixes #

**Changes**
Changes proposed in this pull request:

* adding extraEnv values to each component in the chart
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
