### PR TITLE
[stable/goldilocks]: adding extra env values and update vpa to support e…

### DIFF
--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.14.1"
-version: 10.4.1
+version: 10.5.0
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
@@ -16,7 +16,7 @@ keywords:
   - kubernetes
 dependencies:
   - name: vpa
-    version: 4.12.*
+    version: 4.13.*
     repository: https://charts.fairwinds.com/stable
     condition: vpa.enabled
   - name: metrics-server

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -82,6 +82,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | controller.rbac.extraClusterRoleBindings | list | `[]` | A list of ClusterRoles for which ClusterRoleBindings will be created for the ServiceAccount, if enabled |
 | controller.serviceAccount.create | bool | `true` | If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name` |
 | controller.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `controller.serviceAccount.create` |
+| controller.extraEnv | list | `[]` | Extra environment variables to add to the controller container |
 | controller.flags | object | `{}` | A map of additional flags to pass to the controller. For monitoring all namespaces out of the box, add the following flag "on-by-default: true" |
 | controller.logVerbosity | string | `"2"` | Controller log verbosity. Can be set from 1-10 with 10 being extremely verbose |
 | controller.nodeSelector | object | `{}` | Node selector for the controller pod |
@@ -103,6 +104,7 @@ This will completely remove the VPA and then re-install it using the new method.
 | dashboard.service.type | string | `"ClusterIP"` | The type of the dashboard service |
 | dashboard.service.port | int | `80` | The port to run the dashboard service on |
 | dashboard.service.annotations | object | `{}` | Extra annotations for the dashboard service |
+| dashboard.extraEnv | list | `[]` | Extra environment variables to add to the dashboard container |
 | dashboard.flags | object | `{}` | A map of additional flags to pass to the dashboard. For monitoring all namespaces out of the box, add the following flag "on-by-default: true". |
 | dashboard.logVerbosity | string | `"2"` | Dashboard log verbosity. Can be set from 1-10 with 10 being extremely verbose |
 | dashboard.excludeContainers | string | `"linkerd-proxy,istio-proxy"` | Container names to exclude from displaying in the Goldilocks dashboard |

--- a/stable/goldilocks/templates/controller-deployment.yaml
+++ b/stable/goldilocks/templates/controller-deployment.yaml
@@ -61,6 +61,10 @@ spec:
           securityContext:
             {{- toYaml .Values.controller.securityContext | nindent 12 }}
         {{- end }}
+          {{- with .Values.controller.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
           {{- if .Values.controller.deployment.extraVolumeMounts }}

--- a/stable/goldilocks/templates/dashboard-deployment.yaml
+++ b/stable/goldilocks/templates/dashboard-deployment.yaml
@@ -66,6 +66,10 @@ spec:
           securityContext:
             {{- toYaml .Values.dashboard.securityContext | nindent 12 }}
         {{- end }}
+          {{- with .Values.dashboard.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/stable/goldilocks/values.yaml
+++ b/stable/goldilocks/values.yaml
@@ -46,6 +46,8 @@ controller:
     create: true
     # controller.serviceAccount.name -- The name of an existing service account to use for the controller. Combined with `controller.serviceAccount.create`
     name:
+  # controller.extraEnv -- Extra environment variables to add to the controller container
+  extraEnv: []
   # controller.flags -- A map of additional flags to pass to the controller. For monitoring all namespaces out of the box, add the following flag "on-by-default: true"
   flags: {}
   # controller.logVerbosity -- Controller log verbosity. Can be set from 1-10 with 10 being extremely verbose
@@ -107,6 +109,8 @@ dashboard:
     port: 80
     # dashboard.service.annotations -- Extra annotations for the dashboard service
     annotations: {}
+  # dashboard.extraEnv -- Extra environment variables to add to the dashboard container
+  extraEnv: []
   # dashboard.flags -- A map of additional flags to pass to the dashboard. For monitoring all namespaces out of the box, add the following flag "on-by-default: true".
   flags: {}
   # dashboard.logVerbosity -- Dashboard log verbosity. Can be set from 1-10 with 10 being extremely verbose


### PR DESCRIPTION
**Why This PR?**
Adding support to set extra env values. This could be everything from goldilocks specific to golang specific environment variables

This is currently blocked by: https://github.com/FairwindsOps/charts/pull/1896


**Changes**
Changes proposed in this pull request:

* adding extraEnv values to each component in the chart

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
