### PR TITLE
[stable/insights-agent] Remove grpcPort and autoDetectFromHost; upstream address is set only via grpcAddr

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.21.1
+* Remove `network-observability.aggregator.upstream.grpcPort` and `autoDetectFromHost`; upstream address is set only via `grpcAddr`
+
 ## 5.21.0
 * Bump dependencies
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.21.0
+version: 5.21.1
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -239,9 +239,7 @@ Parameter | Description | Default
 `network-observability.aggregator.disableKube` | Skip Kubernetes enrichment in the aggregator | `false` |
 `network-observability.aggregator.resources` | CPU/memory requests and limits for the aggregator | See values.yaml |
 `network-observability.aggregator.upstream.enabled` | Enable forwarding enriched events to the Insights API | `true` |
-`network-observability.aggregator.upstream.grpcAddr` | Insights network-flow gRPC address; empty disables upstream unless autoDetectFromHost is set | `""` |
-`network-observability.aggregator.upstream.autoDetectFromHost` | Derive upstream gRPC address from `insights.host` | `false` |
-`network-observability.aggregator.upstream.grpcPort` | Port appended when auto-detecting upstream address | `4318` |
+`network-observability.aggregator.upstream.grpcAddr` | Insights network-flow gRPC address (`host:port`); empty disables upstream | `"grpc.insights.fairwinds.com:443"` |
 `network-observability.aggregator.autoscaling.enabled` | Enable HPA for the aggregator Deployment | `false` |
 `network-observability.aggregator.autoscaling.minReplicas` | Minimum aggregator replicas when autoscaling is enabled | `2` |
 `network-observability.aggregator.autoscaling.maxReplicas` | Maximum aggregator replicas when autoscaling is enabled | `5` |

--- a/stable/insights-agent/templates/network-flow-aggregator/deployment.yaml
+++ b/stable/insights-agent/templates/network-flow-aggregator/deployment.yaml
@@ -3,13 +3,8 @@
 {{- $agg := $no.aggregator }}
 {{- $upstream := $agg.upstream }}
 {{- $grpcAddr := "" }}
-{{- if $upstream.enabled }}
-  {{- if $upstream.grpcAddr }}
-    {{- $grpcAddr = $upstream.grpcAddr }}
-  {{- else if $upstream.autoDetectFromHost }}
-    {{- $host := .Values.insights.host | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" }}
-    {{- $grpcAddr = printf "%s:%v" $host $upstream.grpcPort }}
-  {{- end }}
+{{- if and $upstream.enabled $upstream.grpcAddr }}
+  {{- $grpcAddr = $upstream.grpcAddr }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -1195,9 +1195,7 @@ network-observability:
       annotations: {}
     upstream:
       enabled: true
-      grpcAddr: ""
-      autoDetectFromHost: false
-      grpcPort: 4318
+      grpcAddr: "grpc.insights.fairwinds.com:443"
       batchSize: 10000
       flushInterval: "10s"
     autoscaling:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
