### PR TITLE
[stable/insights-agent] Bumping network-flow agent and aggregator to version 0.0.8.

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.23.1
+* Bump network-flow agent and aggregator to `0.0.8`
+
 ## 5.23.0
 * Bump dependencies
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.23.0
+version: 5.23.1
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -215,7 +215,7 @@ Parameter | Description | Default
 `insights-event-watcher.resources` | CPU/memory requests and limits for the watcher | See values.yaml
 `network-observability.enabled` | Enable the network observability agent DaemonSet and aggregator Deployment | `false`
 `network-observability.agent.image.repository` | Repository for the network-flow agent image | `quay.io/fairwinds/network-flow`
-`network-observability.agent.image.tag` | Tag for the network-flow agent image | `0.0.3`
+`network-observability.agent.image.tag` | Tag for the network-flow agent image | `0.0.8`
 `network-observability.agent.gadgetVersion` | Inspektor Gadget version used for gadgets images | `v0.53.1`
 `network-observability.agent.collectorAddr` | Aggregator gRPC address; defaults to the in-cluster aggregator Service | `""`
 `network-observability.agent.batchSize` | Number of flow events to batch before flushing to the aggregator | `5000`
@@ -233,7 +233,7 @@ Parameter | Description | Default
 `network-observability.agent.updateStrategy` | DaemonSet update strategy | `{ type: RollingUpdate }` |
 `network-observability.aggregator.replicas` | Aggregator Deployment replicas (ignored when autoscaling is enabled) | `1` |
 `network-observability.aggregator.image.repository` | Repository for the aggregator image | `quay.io/fairwinds/network-flow-aggregator` |
-`network-observability.aggregator.image.tag` | Tag for the aggregator image | `0.0.3` |
+`network-observability.aggregator.image.tag` | Tag for the aggregator image | `0.0.8` |
 `network-observability.aggregator.maxEvents` | Maximum in-memory flow events retained by the aggregator | `100000` |
 `network-observability.aggregator.maxAge` | Maximum age of retained flow events | `15m` |
 `network-observability.aggregator.disableKube` | Skip Kubernetes enrichment in the aggregator | `false` |

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -1115,7 +1115,7 @@ network-observability:
   agent:
     image:
       repository: quay.io/fairwinds/network-flow
-      tag: "0.0.6"
+      tag: "0.0.8"
       pullPolicy: Always
     gadgetVersion: "v0.53.2"
     collectorAddr: ""
@@ -1164,7 +1164,7 @@ network-observability:
   aggregator:
     image:
       repository: quay.io/fairwinds/network-flow-aggregator
-      tag: "0.0.6"
+      tag: "0.0.8"
       pullPolicy: Always
     replicas: 1
     grpcPort: 4317


### PR DESCRIPTION
**Why This PR?**

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
