### PR TITLE
[stable/insights-agent] tuning network-observability defaults to reduce OOM risk

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.24.2
+* Tune network-observability defaults to reduce OOM risk.
+
 ## 5.24.1
 * Bump network-flow agent and aggregator to use `0.0`, remove gadget version override
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.24.1
+version: 5.24.2
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -1120,7 +1120,7 @@ network-observability:
     gadgetVersion: ""
     collectorAddr: ""
     batchSize: 5000
-    maxPendingEvents: 50000
+    maxPendingEvents: 25000
     flushInterval: "5s"
     logLevel: info
     ig:
@@ -1129,7 +1129,7 @@ network-observability:
       hookMode: auto
     resources:
       requests:
-        cpu: 100m
+        cpu: 50m
         memory: 128Mi
       limits:
         cpu: 500m
@@ -1175,11 +1175,11 @@ network-observability:
     logLevel: info
     resources:
       requests:
-        cpu: 50m
-        memory: 64Mi
+        cpu: 100m
+        memory: 256Mi
       limits:
         cpu: 500m
-        memory: 256Mi
+        memory: 768Mi
     service:
       type: ClusterIP
       annotations: {}


### PR DESCRIPTION
tuning network-observability defaults to reduce OOM risk and adjusting resource limits in values.yaml

**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
