### PR TITLE
INS-2604 - Configure network-flow agent and aggregator via env vars and omit values that match binary defaults

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.24.3
+* Configure network-flow agent and aggregator via env vars; omit values that match binary defaults
+
 ## 5.24.2
 * Tune network-observability defaults to reduce OOM risk.
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.24.2
+version: 5.24.3
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -218,10 +218,10 @@ Parameter | Description | Default
 `network-observability.agent.image.tag` | Tag for the network-flow agent image | `0.0`
 `network-observability.agent.gadgetVersion` | Inspektor Gadget version used for gadgets images. When empty, uses plugins default | `""`
 `network-observability.agent.collectorAddr` | Aggregator gRPC address; defaults to the in-cluster aggregator Service | `""`
-`network-observability.agent.batchSize` | Number of flow events to batch before flushing to the aggregator | `5000`
-`network-observability.agent.maxPendingEvents` | Maximum pending events before drop-oldest retention | `50000`
-`network-observability.agent.flushInterval` | Interval to flush batched events | `5s`
-`network-observability.agent.logLevel` | Log level for the agent | `info`
+`network-observability.agent.batchSize` | Number of flow events to batch before flushing to the aggregator; empty uses binary default (`5000`) | `""`
+`network-observability.agent.maxPendingEvents` | Maximum pending events before drop-oldest retention (chart default is lower than binary `50000` to reduce OOM risk) | `25000`
+`network-observability.agent.flushInterval` | Interval to flush batched events; empty uses binary default (`5s`) | `""`
+`network-observability.agent.logLevel` | Log level for the agent; empty uses binary default (`info`) | `""`
 `network-observability.agent.ig.eventsBufferLength` | Inspektor Gadget events buffer length | `32768`
 `network-observability.agent.ig.daemonLogLevel` | Inspektor Gadget daemon log level | `info`
 `network-observability.agent.ig.hookMode` | Inspektor Gadget kube manager hook mode | `auto`
@@ -234,9 +234,12 @@ Parameter | Description | Default
 `network-observability.aggregator.replicas` | Aggregator Deployment replicas (ignored when autoscaling is enabled) | `1` |
 `network-observability.aggregator.image.repository` | Repository for the aggregator image | `quay.io/fairwinds/network-flow-aggregator` |
 `network-observability.aggregator.image.tag` | Tag for the aggregator image | `0.0` |
-`network-observability.aggregator.maxEvents` | Maximum in-memory flow events retained by the aggregator | `100000` |
-`network-observability.aggregator.maxAge` | Maximum age of retained flow events | `15m` |
+`network-observability.aggregator.maxEvents` | Maximum in-memory flow events retained by the aggregator; empty uses binary default (`100000`) | `""` |
+`network-observability.aggregator.maxAge` | Maximum age of retained flow events; empty uses binary default (`15m`) | `""` |
 `network-observability.aggregator.disableKube` | Skip Kubernetes enrichment in the aggregator | `false` |
+`network-observability.aggregator.logLevel` | Aggregator log level; empty uses binary default (`info`) | `""` |
+`network-observability.aggregator.upstream.batchSize` | Insights upstream send batch size; empty uses binary default (`10000`) | `""` |
+`network-observability.aggregator.upstream.flushInterval` | Insights upstream flush interval; empty uses binary default (`10s`) | `""` |
 `network-observability.aggregator.resources` | CPU/memory requests and limits for the aggregator | See values.yaml |
 `network-observability.aggregator.upstream.enabled` | Enable forwarding enriched events to the Insights API | `true` |
 `network-observability.aggregator.upstream.grpcAddr` | Insights network-flow gRPC address (`host:port`); empty disables upstream | `"grpc.insights.fairwinds.com:443"` |

--- a/stable/insights-agent/templates/network-flow-aggregator/deployment.yaml
+++ b/stable/insights-agent/templates/network-flow-aggregator/deployment.yaml
@@ -59,28 +59,32 @@ spec:
           image: "{{ $agg.image.repository }}:{{ $agg.image.tag }}"
           imagePullPolicy: {{ $agg.image.pullPolicy }}
           command: ["network-flow-aggregator"]
-          args:
-            - -grpc-addr=:{{ $agg.grpcPort }}
-            - -http-addr=:{{ $agg.httpPort }}
-            - -max-events={{ $agg.maxEvents }}
-            - -max-age={{ $agg.maxAge }}
-            - -log-level={{ $agg.logLevel }}
-            {{- if $agg.disableKube }}
-            - -disable-kube
-            {{- end }}
-            {{- if $grpcAddr }}
-            - -insights-grpc-addr={{ $grpcAddr }}
-            - -organization={{ .Values.insights.organization }}
-            - -cluster={{ .Values.insights.cluster }}
-            - -upstream-batch-size={{ $upstream.batchSize }}
-            - -upstream-flush-interval={{ $upstream.flushInterval }}
-            {{- end }}
           ports:
             - name: grpc
               containerPort: {{ $agg.grpcPort }}
             - name: http
               containerPort: {{ $agg.httpPort }}
           env:
+            - name: GRPC_ADDR
+              value: ":{{ $agg.grpcPort }}"
+            - name: HTTP_ADDR
+              value: ":{{ $agg.httpPort }}"
+            {{- if $agg.maxEvents }}
+            - name: MAX_EVENTS
+              value: {{ $agg.maxEvents | quote }}
+            {{- end }}
+            {{- if $agg.maxAge }}
+            - name: MAX_AGE
+              value: {{ $agg.maxAge | quote }}
+            {{- end }}
+            {{- if $agg.logLevel }}
+            - name: LOG_LEVEL
+              value: {{ $agg.logLevel | quote }}
+            {{- end }}
+            {{- if $agg.disableKube }}
+            - name: DISABLE_KUBE
+              value: "true"
+            {{- end }}
             {{- if $grpcAddr }}
             - name: INSIGHTS_GRPC_ADDR
               value: {{ $grpcAddr | quote }}
@@ -97,10 +101,14 @@ spec:
                   name: {{ include "insights-agent.fullname" . }}-token
                   {{- end }}
                   key: token
+            {{- if $upstream.batchSize }}
             - name: UPSTREAM_BATCH_SIZE
               value: {{ $upstream.batchSize | quote }}
+            {{- end }}
+            {{- if $upstream.flushInterval }}
             - name: UPSTREAM_FLUSH_INTERVAL
               value: {{ $upstream.flushInterval | quote }}
+            {{- end }}
             {{- end }}
             {{ include "proxy-env-spec" . | indent 12 | trim }}
             {{- range $key, $value := $agg.env }}

--- a/stable/insights-agent/templates/network-flow/daemonset.yaml
+++ b/stable/insights-agent/templates/network-flow/daemonset.yaml
@@ -68,16 +68,22 @@ spec:
                   fieldPath: spec.nodeName
             - name: COLLECTOR_ADDR
               value: {{ $collectorAddr | quote }}
+            {{- if $agent.maxPendingEvents }}
             - name: MAX_PENDING_EVENTS
               value: {{ $agent.maxPendingEvents | quote }}
+            {{- end }}
+            {{- if $agent.batchSize }}
             - name: BATCH_SIZE
               value: {{ $agent.batchSize | quote }}
+            {{- end }}
+            {{- if $agent.flushInterval }}
             - name: FLUSH_INTERVAL
               value: {{ $agent.flushInterval | quote }}
+            {{- end }}
+            {{- if $agent.logLevel }}
             - name: LOG_LEVEL
               value: {{ $agent.logLevel | quote }}
-            - name: IG_ADDR
-              value: tcp://127.0.0.1:8080
+            {{- end }}
             {{- if $gadgetVersion }}
             - name: TRACE_TCP_IMAGE
               value: ghcr.io/inspektor-gadget/gadget/trace_tcp:{{ $gadgetVersion }}

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -1120,7 +1120,7 @@ network-observability:
     gadgetVersion: ""
     collectorAddr: ""
     batchSize: ""
-    maxPendingEvents: ""
+    maxPendingEvents: 25000"
     flushInterval: ""
     logLevel: ""
     ig:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -1119,10 +1119,10 @@ network-observability:
       pullPolicy: Always
     gadgetVersion: ""
     collectorAddr: ""
-    batchSize: 5000
-    maxPendingEvents: 25000
-    flushInterval: "5s"
-    logLevel: info
+    batchSize: ""
+    maxPendingEvents: ""
+    flushInterval: ""
+    logLevel: ""
     ig:
       eventsBufferLength: 32768
       daemonLogLevel: info
@@ -1169,10 +1169,10 @@ network-observability:
     replicas: 1
     grpcPort: 4317
     httpPort: 8080
-    maxEvents: 100000
-    maxAge: "15m"
+    maxEvents: ""
+    maxAge: ""
     disableKube: false
-    logLevel: info
+    logLevel: ""
     resources:
       requests:
         cpu: 100m
@@ -1196,8 +1196,8 @@ network-observability:
     upstream:
       enabled: true
       grpcAddr: "grpc.insights.fairwinds.com:443"
-      batchSize: 10000
-      flushInterval: "10s"
+      batchSize: ""
+      flushInterval: ""
     autoscaling:
       enabled: false
       minReplicas: 2

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -1120,7 +1120,7 @@ network-observability:
     gadgetVersion: ""
     collectorAddr: ""
     batchSize: ""
-    maxPendingEvents: 25000"
+    maxPendingEvents: 25000
     flushInterval: ""
     logLevel: ""
     ig:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
