### PR TITLE
[stable/insights-agent] Update ClusterRole for network-flow-aggregator to include permissions on nodes

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.27.1
+* Grant network-flow-aggregator ClusterRole `get`/`list`/`watch` on `nodes`
+
 ## 5.27.0
 * Bumped `workloads` to `2.14`
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.27.0
+version: 5.27.1
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/network-flow-aggregator/rbac.yaml
+++ b/stable/insights-agent/templates/network-flow-aggregator/rbac.yaml
@@ -9,7 +9,7 @@ metadata:
     component: network-flow-aggregator
 rules:
   - apiGroups: [""]
-    resources: ["pods", "services"]
+    resources: ["nodes", "pods", "services"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
