### PR TITLE
[stable/insights-agent] INS-2636: Bump workloads and fix permissions on karpenter CRDs

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.28.0
+* Bumped `workloads` to `2.15`
+* Grant workloads ClusterRole `get`/`list` on Karpenter `nodepools`/`nodeclaims` (`karpenter.sh`) and `ec2nodeclasses` (`karpenter.k8s.aws`) for inventory
+
 ## 5.27.2
 * Bumped `dcgm-exporter` to `4.8.3`
 

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.27.2
+version: 5.28.0
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/templates/workloads/rbac.yaml
+++ b/stable/insights-agent/templates/workloads/rbac.yaml
@@ -20,6 +20,22 @@ rules:
     verbs:
       - 'get'
       - 'list'
+  # Optional Karpenter inventory (workloads 2.15+). Soft-fails empty without these CRDs/RBAC.
+  - apiGroups:
+      - 'karpenter.sh'
+    resources:
+      - 'nodepools'
+      - 'nodeclaims'
+    verbs:
+      - 'get'
+      - 'list'
+  - apiGroups:
+      - 'karpenter.k8s.aws'
+    resources:
+      - 'ec2nodeclasses'
+    verbs:
+      - 'get'
+      - 'list'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/stable/insights-agent/templates/workloads/rbac.yaml
+++ b/stable/insights-agent/templates/workloads/rbac.yaml
@@ -20,7 +20,8 @@ rules:
     verbs:
       - 'get'
       - 'list'
-  # Optional Karpenter inventory (workloads 2.15+). Soft-fails empty without these CRDs/RBAC.
+  # Optional Karpenter inventory (workloads 2.15+). Without these CRDs the plugin
+  # omits top-level Karpenter; without RBAC it emits Karpenter with empty nested arrays.
   - apiGroups:
       - 'karpenter.sh'
     resources:

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -212,7 +212,7 @@ workloads:
   timeout: 300
   image:
     repository: quay.io/fairwinds/workloads
-    tag: "2.14"
+    tag: "2.15"
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
