### PR TITLE
[stable/fairwinds-insights] Set CronJob job history limits for successful and failed jobs to 1

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.13.5
+* Set CronJob job history limits to 1 successful and 1 failed (overridable per cronjob)
+
 ## 9.13.4
 * Bumped `insights-api` to `18.3.73`
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.3.73"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 9.13.4
+version: 9.13.5
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -41,6 +41,8 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | cronjobOptions.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | Default security context for cronjobs |
 | cronjobOptions.resources | object | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Default resources for cronjobs |
 | cronjobOptions.additionalEnvVars | list | `[{"name":"POSTGRES_MAX_IDLE_CONNS","value":"1"},{"name":"POSTGRES_MAX_OPEN_CONNS","value":"1"}]` | Default additional env vars for all cronjobs (overridden per cronjob by cronjobs.<name>.additionalEnvVars) |
+| cronjobOptions.successfulJobsHistoryLimit | int | `1` | Default successful jobs history limit (overridden per cronjob by cronjobs.<name>.successfulJobsHistoryLimit) |
+| cronjobOptions.failedJobsHistoryLimit | int | `1` | Default failed jobs history limit (overridden per cronjob by cronjobs.<name>.failedJobsHistoryLimit) |
 | cronjobs.action-item-filters-refresh | object | `{"command":"action_items_filters_refresher","schedule":"0/15 * * * *"}` | Options for the action-items filters refresher job. |
 | cronjobs.action-items-statistics | object | `{"command":"action_items_statistics","schedule":"15 * * * *"}` | Options for the action item stats job |
 | cronjobs.benchmark | object | `{"command":"benchmark","schedule":""}` | Options for the benchmark job |

--- a/stable/fairwinds-insights/templates/cronjobs.yaml
+++ b/stable/fairwinds-insights/templates/cronjobs.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   schedule: "{{ $options.schedule }}"
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ dig "successfulJobsHistoryLimit" $.Values.cronjobOptions.successfulJobsHistoryLimit $options }}
+  failedJobsHistoryLimit: {{ dig "failedJobsHistoryLimit" $.Values.cronjobOptions.failedJobsHistoryLimit $options }}
   jobTemplate:
     spec:
       template:

--- a/stable/fairwinds-insights/templates/health-scores-migration.job.yaml
+++ b/stable/fairwinds-insights/templates/health-scores-migration.job.yaml
@@ -10,6 +10,8 @@ spec:
   schedule: "0 0 1 1 0"
   concurrencyPolicy: Forbid
   suspend: true
+  successfulJobsHistoryLimit: {{ dig "successfulJobsHistoryLimit" $.Values.cronjobOptions.successfulJobsHistoryLimit $.Values.migrateHealthScoreJob }}
+  failedJobsHistoryLimit: {{ dig "failedJobsHistoryLimit" $.Values.cronjobOptions.failedJobsHistoryLimit $.Values.migrateHealthScoreJob }}
   jobTemplate:
     spec:
       template:

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -98,6 +98,10 @@ cronjobOptions:
       value: "1"
     - name: POSTGRES_MAX_OPEN_CONNS
       value: "1"
+  # -- Default successful jobs history limit (overridden per cronjob by cronjobs.<name>.successfulJobsHistoryLimit)
+  successfulJobsHistoryLimit: 1
+  # -- Default failed jobs history limit (overridden per cronjob by cronjobs.<name>.failedJobsHistoryLimit)
+  failedJobsHistoryLimit: 1
 
 cronjobs:
   # -- Options for the action-items filters refresher job.


### PR DESCRIPTION
**Why This PR?**
Set CronJob job history limits for successful and failed jobs to 1 - configurable per cronjob

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
