### PR TITLE
[stable/insights-agent] Reduced successful and failed job history limits for CronJobs to 1 each

### DIFF
--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.28.1
+* Reduce CronJob job history limits to 1 successful and 1 failed
+
 ## 5.28.0
 * Bumped `workloads` to `2.15`
 * Grant workloads ClusterRole `get`/`list` on Karpenter `nodepools`/`nodeclaims` (`karpenter.sh`) and `ec2nodeclasses` (`karpenter.k8s.aws`) for inventory

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.28.0
+version: 5.28.1
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -81,8 +81,8 @@ Parameter | Description | Default
 `cronjobs.disableServiceMesh` | Adds annotations to all CronJobs to not inject Linkerd or Istio | true
 `cronjobs.backoffLimit` | Backoff limit to use for each report CronJob | 1
 `cronjobs.imagePullSecret` | A pull secret for cronjob images
-`cronjobs.failedJobsHistoryLimit` | Number of failed jobs to keep in history for each report | 2
-`cronjobs.successfulJobsHistoryLimit` | Number of successful jobs to keep in history for each report | 2
+`cronjobs.failedJobsHistoryLimit` | Number of failed jobs to keep in history for each report | 1
+`cronjobs.successfulJobsHistoryLimit` | Number of successful jobs to keep in history for each report | 1
 `cronjobs.nodeSelector` | Node selector to use for cronjobs | null
 `cronjobs.tolerations` | Tolerations to use for cronjobs | null
 `cronjobs.runJobsImmediately` | Run each of the reports immediately upon install of the Insights Agent | true

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -46,8 +46,8 @@ cronjobs:
   apiVersion: ""
   disableServiceMesh: true
   backoffLimit: 1
-  failedJobsHistoryLimit: 2
-  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 1
   nodeSelector: null
   runJobsImmediately: true
   # tolerations:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
