### PR TITLE
[incubator/fairwinds-metrics] switch custom-metrics image default to GAR

### DIFF
--- a/incubator/fairwinds-metrics/Chart.yaml
+++ b/incubator/fairwinds-metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.6.0"
 description: A Helm chart for running Fairwinds Custom Metrics
 name: fairwinds-metrics
-version: 0.6.0
+version: 0.6.1
 maintainers:
   - name: sudermanjr
   - name: lucasreed

--- a/incubator/fairwinds-metrics/README.md
+++ b/incubator/fairwinds-metrics/README.md
@@ -27,23 +27,23 @@ Also, if you don't need the istio root CA expire check and want to limit the RBA
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| controller.affinity | object | `{}` | Affinity for the controller pods |
-| controller.datadogAnnotations.enabled | bool | `true` | If set to true, the controller will add datadog annotations to the pods |
-| controller.enabled | bool | `true` | Whether or not to install the controller deployment |
-| controller.env | object | `{}` | Map of environment var name and value to be set on the controller pods |
-| controller.istio.enabled | bool | `true` |  |
-| controller.logVerbosity | string | `"2"` | The verbosity of the controller's logs |
-| controller.nodeSelector | object | `{}` | Node selector for the controller pod |
-| controller.rbac.create | bool | `true` | If set to true, rbac resources will be created for the controller |
-| controller.resources | object | `{"limits":{"cpu":"25m","memory":"32Mi"},"requests":{"cpu":"25m","memory":"32Mi"}}` | The resources block for the controller pods |
-| controller.service.enabled | bool | `true` | If set to true, the controller will create a service for the controller |
-| controller.service.port | int | `10042` | The port to run the dashboard service on |
-| controller.service.type | string | `"ClusterIP"` | The type of service to create. |
-| controller.serviceAccount.create | bool | `true` | If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name` |
-| controller.serviceAccount.name | string | `nil` |  |
-| controller.tolerations | list | `[]` | Tolerations for the controller podons - List of tolerations to put on the deployment pods |
-| fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as `Always` |
 | image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/custom-metrics"` | Repository for the custom-metrics image |
 | image.tag | string | `"v0.6.0"` | The custom-metrics image tag to use |
+| image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as `Always` |
 | nameOverride | string | `""` |  |
+| fullnameOverride | string | `""` |  |
+| controller.enabled | bool | `true` | Whether or not to install the controller deployment |
+| controller.istio.enabled | bool | `true` |  |
+| controller.rbac.create | bool | `true` | If set to true, rbac resources will be created for the controller |
+| controller.serviceAccount.create | bool | `true` | If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name` |
+| controller.serviceAccount.name | string | `nil` |  |
+| controller.datadogAnnotations.enabled | bool | `true` | If set to true, the controller will add datadog annotations to the pods |
+| controller.logVerbosity | string | `"2"` | The verbosity of the controller's logs |
+| controller.env | object | `{}` | Map of environment var name and value to be set on the controller pods |
+| controller.nodeSelector | object | `{}` | Node selector for the controller pod |
+| controller.tolerations | list | `[]` | Tolerations for the controller podons - List of tolerations to put on the deployment pods |
+| controller.affinity | object | `{}` | Affinity for the controller pods |
+| controller.resources | object | `{"limits":{"cpu":"25m","memory":"32Mi"},"requests":{"cpu":"25m","memory":"32Mi"}}` | The resources block for the controller pods |
+| controller.service.enabled | bool | `true` | If set to true, the controller will create a service for the controller |
+| controller.service.type | string | `"ClusterIP"` | The type of service to create. |
+| controller.service.port | int | `10042` | The port to run the dashboard service on |

--- a/incubator/fairwinds-metrics/README.md
+++ b/incubator/fairwinds-metrics/README.md
@@ -27,23 +27,23 @@ Also, if you don't need the istio root CA expire check and want to limit the RBA
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.repository | string | `"quay.io/fairwinds/custom-metrics"` | Repository for the custom-metrics image |
-| image.tag | string | `"v0.6.0"` | The custom-metrics image tag to use |
-| image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as `Always` |
-| nameOverride | string | `""` |  |
-| fullnameOverride | string | `""` |  |
-| controller.enabled | bool | `true` | Whether or not to install the controller deployment |
-| controller.istio.enabled | bool | `true` |  |
-| controller.rbac.create | bool | `true` | If set to true, rbac resources will be created for the controller |
-| controller.serviceAccount.create | bool | `true` | If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name` |
-| controller.serviceAccount.name | string | `nil` |  |
-| controller.datadogAnnotations.enabled | bool | `true` | If set to true, the controller will add datadog annotations to the pods |
-| controller.logVerbosity | string | `"2"` | The verbosity of the controller's logs |
-| controller.env | object | `{}` | Map of environment var name and value to be set on the controller pods |
-| controller.nodeSelector | object | `{}` | Node selector for the controller pod |
-| controller.tolerations | list | `[]` | Tolerations for the controller podons - List of tolerations to put on the deployment pods |
 | controller.affinity | object | `{}` | Affinity for the controller pods |
+| controller.datadogAnnotations.enabled | bool | `true` | If set to true, the controller will add datadog annotations to the pods |
+| controller.enabled | bool | `true` | Whether or not to install the controller deployment |
+| controller.env | object | `{}` | Map of environment var name and value to be set on the controller pods |
+| controller.istio.enabled | bool | `true` |  |
+| controller.logVerbosity | string | `"2"` | The verbosity of the controller's logs |
+| controller.nodeSelector | object | `{}` | Node selector for the controller pod |
+| controller.rbac.create | bool | `true` | If set to true, rbac resources will be created for the controller |
 | controller.resources | object | `{"limits":{"cpu":"25m","memory":"32Mi"},"requests":{"cpu":"25m","memory":"32Mi"}}` | The resources block for the controller pods |
 | controller.service.enabled | bool | `true` | If set to true, the controller will create a service for the controller |
-| controller.service.type | string | `"ClusterIP"` | The type of service to create. |
 | controller.service.port | int | `10042` | The port to run the dashboard service on |
+| controller.service.type | string | `"ClusterIP"` | The type of service to create. |
+| controller.serviceAccount.create | bool | `true` | If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name` |
+| controller.serviceAccount.name | string | `nil` |  |
+| controller.tolerations | list | `[]` | Tolerations for the controller podons - List of tolerations to put on the deployment pods |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as `Always` |
+| image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/custom-metrics"` | Repository for the custom-metrics image |
+| image.tag | string | `"v0.6.0"` | The custom-metrics image tag to use |
+| nameOverride | string | `""` |  |

--- a/incubator/fairwinds-metrics/values.yaml
+++ b/incubator/fairwinds-metrics/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   # image.repository -- Repository for the custom-metrics image
-  repository: quay.io/fairwinds/custom-metrics
+  repository: us-docker.pkg.dev/fairwinds-ops/oss/custom-metrics
   # image.tag -- The custom-metrics image tag to use
   tag: v0.6.0
   # image.pullPolicy -- imagePullPolicy - Highly recommended to leave this as `Always`


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
