### PR TITLE
[stable/astro] switch astro image default to GAR and pin v1.6.0

### DIFF
--- a/stable/astro/Chart.yaml
+++ b/stable/astro/Chart.yaml
@@ -1,7 +1,7 @@
 name: astro
-version: 1.0.14
+version: 1.1.0
 apiVersion: v1
-appVersion: "1.5.3"
+appVersion: "1.6.0"
 kubeVersion: ">= 1.22.0-0"
 description: Emit datadog monitors based on kubernetes state.
 keywords:

--- a/stable/astro/Chart.yaml
+++ b/stable/astro/Chart.yaml
@@ -1,5 +1,5 @@
 name: astro
-version: 1.1.0
+version: 2.0.0
 apiVersion: v1
 appVersion: "1.6.0"
 kubeVersion: ">= 1.22.0-0"

--- a/stable/astro/README.md
+++ b/stable/astro/README.md
@@ -15,6 +15,10 @@ We recommend installing astro in its own namespace and with a simple release nam
 helm repo add fairwinds-stable https://charts.fairwinds.com/stable
 helm install astro fairwinds-stable/astro --namespace astro
 ```
+
+## Changes in 2.0.0
+The default image now comes from Google Artifact Registry (`us-docker.pkg.dev/fairwinds-ops/oss/astro`) instead of Quay. If you mirror images or allow registries explicitly, update your configuration before upgrading.
+
 ## Changes to chart values in 1.0.0+
 When upgrading from a chart version below 1.0.0 to 1.0.0+ take into account the following changes in values:
 

--- a/stable/astro/README.md
+++ b/stable/astro/README.md
@@ -34,24 +34,24 @@ Kubernetes 1.11+, Helm 2.13+
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.repository | string | `"quay.io/fairwinds/astro"` | Docker image repo |
-| image.tag | string | `"v1.5.3"` | Docker image tag |
-| image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
-| resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | The resources block for the deployment. |
-| nodeSelector | object | `{}` | Deployment ndoeSelector |
-| tolerations | list | `[]` | Deployment tolerations |
 | affinity | object | `{}` | Deployment affinity |
+| custom_config.data | string | "" | An astro configuration file. See the [Astro repo readme](https://github.com/fairwindsops/astro) for more details. |
+| custom_config.enabled | bool | `false` | If true a custom configuration must be specified in `custom_config.data`. |
 | datadog.apiKey | string | `""` | Datadog API key |
 | datadog.appKey | string | `""` | Datadog app key |
-| rbac.create | bool | `true` | If true, RBAC resources will be created. |
+| definitionsPath | string | `"conf.yml"` | The path to the monitor definitions configuration. This can be a local path or a URL. |
 | deployment.env | string | `nil` | Map of key value pairs for environment variables to pass into deployment. Ex.: env:   THING: value   THING2: value2 |
+| deployment.replicas | int | `2` | The number of replicas to use. |
 | deployment.serviceAccount.create | bool | `true` | If true, a service account will be created. If false, you must set `deployment.serviceAccount.name`. |
 | deployment.serviceAccount.name | string | `nil` | The name of an existing service account to use. |
-| deployment.replicas | int | `2` | The number of replicas to use. |
+| dryRun | bool | `false` | When set to true monitors will not be managed in datadog. |
+| image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
+| image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/astro"` | Docker image repo |
+| image.tag | string | `"v1.6.0"` | Docker image tag |
+| nodeSelector | object | `{}` | Deployment ndoeSelector |
+| owner | string | `"astro"` | A unique name to designate as teh owner. This will be applied as a tag to identified managed monitors. |
+| rbac.create | bool | `true` | If true, RBAC resources will be created. |
+| resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | The resources block for the deployment. |
 | secret.create | bool | `true` | If true, a secret with API credentials will be created. If false, you must set `secret.name` |
 | secret.name | string | `nil` | The name of an existing secret to mount to the container. |
-| definitionsPath | string | `"conf.yml"` | The path to the monitor definitions configuration. This can be a local path or a URL. |
-| owner | string | `"astro"` | A unique name to designate as teh owner. This will be applied as a tag to identified managed monitors. |
-| dryRun | bool | `false` | When set to true monitors will not be managed in datadog. |
-| custom_config.enabled | bool | `false` | If true a custom configuration must be specified in `custom_config.data`. |
-| custom_config.data | string | "" | An astro configuration file. See the [Astro repo readme](https://github.com/fairwindsops/astro) for more details. |
+| tolerations | list | `[]` | Deployment tolerations |

--- a/stable/astro/README.md
+++ b/stable/astro/README.md
@@ -34,24 +34,24 @@ Kubernetes 1.11+, Helm 2.13+
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{}` | Deployment affinity |
-| custom_config.data | string | "" | An astro configuration file. See the [Astro repo readme](https://github.com/fairwindsops/astro) for more details. |
-| custom_config.enabled | bool | `false` | If true a custom configuration must be specified in `custom_config.data`. |
-| datadog.apiKey | string | `""` | Datadog API key |
-| datadog.appKey | string | `""` | Datadog app key |
-| definitionsPath | string | `"conf.yml"` | The path to the monitor definitions configuration. This can be a local path or a URL. |
-| deployment.env | string | `nil` | Map of key value pairs for environment variables to pass into deployment. Ex.: env:   THING: value   THING2: value2 |
-| deployment.replicas | int | `2` | The number of replicas to use. |
-| deployment.serviceAccount.create | bool | `true` | If true, a service account will be created. If false, you must set `deployment.serviceAccount.name`. |
-| deployment.serviceAccount.name | string | `nil` | The name of an existing service account to use. |
-| dryRun | bool | `false` | When set to true monitors will not be managed in datadog. |
-| image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/astro"` | Docker image repo |
 | image.tag | string | `"v1.6.0"` | Docker image tag |
-| nodeSelector | object | `{}` | Deployment ndoeSelector |
-| owner | string | `"astro"` | A unique name to designate as teh owner. This will be applied as a tag to identified managed monitors. |
-| rbac.create | bool | `true` | If true, RBAC resources will be created. |
+| image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | The resources block for the deployment. |
+| nodeSelector | object | `{}` | Deployment ndoeSelector |
+| tolerations | list | `[]` | Deployment tolerations |
+| affinity | object | `{}` | Deployment affinity |
+| datadog.apiKey | string | `""` | Datadog API key |
+| datadog.appKey | string | `""` | Datadog app key |
+| rbac.create | bool | `true` | If true, RBAC resources will be created. |
+| deployment.env | string | `nil` | Map of key value pairs for environment variables to pass into deployment. Ex.: env:   THING: value   THING2: value2 |
+| deployment.serviceAccount.create | bool | `true` | If true, a service account will be created. If false, you must set `deployment.serviceAccount.name`. |
+| deployment.serviceAccount.name | string | `nil` | The name of an existing service account to use. |
+| deployment.replicas | int | `2` | The number of replicas to use. |
 | secret.create | bool | `true` | If true, a secret with API credentials will be created. If false, you must set `secret.name` |
 | secret.name | string | `nil` | The name of an existing secret to mount to the container. |
-| tolerations | list | `[]` | Deployment tolerations |
+| definitionsPath | string | `"conf.yml"` | The path to the monitor definitions configuration. This can be a local path or a URL. |
+| owner | string | `"astro"` | A unique name to designate as teh owner. This will be applied as a tag to identified managed monitors. |
+| dryRun | bool | `false` | When set to true monitors will not be managed in datadog. |
+| custom_config.enabled | bool | `false` | If true a custom configuration must be specified in `custom_config.data`. |
+| custom_config.data | string | "" | An astro configuration file. See the [Astro repo readme](https://github.com/fairwindsops/astro) for more details. |

--- a/stable/astro/README.md.gotmpl
+++ b/stable/astro/README.md.gotmpl
@@ -15,6 +15,10 @@ We recommend installing astro in its own namespace and with a simple release nam
 helm repo add fairwinds-stable https://charts.fairwinds.com/stable
 helm install astro fairwinds-stable/astro --namespace astro
 ```
+
+## Changes in 2.0.0
+The default image now comes from Google Artifact Registry (`us-docker.pkg.dev/fairwinds-ops/oss/astro`) instead of Quay. If you mirror images or allow registries explicitly, update your configuration before upgrading.
+
 ## Changes to chart values in 1.0.0+
 When upgrading from a chart version below 1.0.0 to 1.0.0+ take into account the following changes in values:
 

--- a/stable/astro/values.yaml
+++ b/stable/astro/values.yaml
@@ -1,8 +1,8 @@
 image:
   # -- Docker image repo
-  repository: quay.io/fairwinds/astro
+  repository: us-docker.pkg.dev/fairwinds-ops/oss/astro
   # -- Docker image tag
-  tag: "v1.5.3"
+  tag: "v1.6.0"
   # -- Docker image pull policy
   pullPolicy: IfNotPresent
 # -- The resources block for the deployment.


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
