### PR TITLE
[incubator/opa] Switch chart ci-images references to GAR

### DIFF
--- a/incubator/opa/Chart.yaml
+++ b/incubator/opa/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "0.0.1"
 description: A Helm chart to manage opa
 name: opa
-version: 0.1.3
+version: 0.1.4
 maintainers:
   - name: sudermanjr

--- a/incubator/opa/Chart.yaml
+++ b/incubator/opa/Chart.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 appVersion: "0.0.1"
-description: A Helm chart to manage opa
+description: >-
+  DEPRECATED: This chart is no longer maintained and cannot be installed on
+  Kubernetes 1.25 or newer, since it renders API versions that have been
+  removed. It may be removed from this repository in a future release. Use Fairwinds Insights instead.
+deprecated: true
 name: opa
 version: 0.1.4
 maintainers:

--- a/incubator/opa/README.md
+++ b/incubator/opa/README.md
@@ -1,5 +1,7 @@
 # OPA Chart
 
+> **DEPRECATED AND UNMAINTAINED.** This chart cannot be installed on Kubernetes 1.25 or newer: it renders deprecated and/or removed resources. It is excluded from CI and may be removed from this repository in a future release. Use Fairwinds Insights instead.
+
 This chart will install the OPA controller and validating webhook to utilize it. It includes a default set of policies and allows the installation of additional policy.
 
 ## How Does This Work?

--- a/incubator/opa/templates/ca-updater-cronjob.yaml
+++ b/incubator/opa/templates/ca-updater-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: {{ include "opa.name" . }}-ca-updater
           containers:
           - name: fix-validating-cabundle
-            image: quay.io/reactiveops/ci-images:v8-alpine
+            image: us-docker.pkg.dev/fairwinds-ops/oss/ci-images:v8-alpine
             command: ["bash"]
             args:
               - -c

--- a/incubator/opa/templates/ca-updater-hook.yaml
+++ b/incubator/opa/templates/ca-updater-hook.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: {{ include "opa.fullname" . }}
       containers:
       - name: start-job-from-cronjob
-        image: quay.io/reactiveops/ci-images:v8-alpine
+        image: us-docker.pkg.dev/fairwinds-ops/oss/ci-images:v8-alpine
         command: ["bash"]
         args:
           - -c

--- a/incubator/opa/templates/selfsigned-hook.yaml
+++ b/incubator/opa/templates/selfsigned-hook.yaml
@@ -75,7 +75,7 @@ spec:
       serviceAccountName: {{ include "opa.name" . }}-selfsigned-cert-gen
       containers:
       - name: start-job-from-cronjob
-        image: quay.io/reactiveops/ci-images:v8-alpine
+        image: us-docker.pkg.dev/fairwinds-ops/oss/ci-images:v8-alpine
         command: ["bash"]
         args:
           - -c

--- a/incubator/opa/templates/tests/check-custom-policy.yaml
+++ b/incubator/opa/templates/tests/check-custom-policy.yaml
@@ -14,7 +14,7 @@ spec:
   serviceAccountName: {{ include "opa.fullname" . }}
   containers:
   - name: {{ .Release.Name }}-policies-test
-    image: quay.io/reactiveops/ci-images:v8-alpine
+    image: us-docker.pkg.dev/fairwinds-ops/oss/ci-images:v8-alpine
     env:
     command:
       - bash

--- a/incubator/opa/templates/tests/check-default-policy.yaml
+++ b/incubator/opa/templates/tests/check-default-policy.yaml
@@ -9,7 +9,7 @@ spec:
   serviceAccountName: {{ include "opa.fullname" . }}
   containers:
   - name: {{ .Release.Name }}-policies-test
-    image: quay.io/reactiveops/ci-images:v8-alpine
+    image: us-docker.pkg.dev/fairwinds-ops/oss/ci-images:v8-alpine
     env:
     command:
       - bash

--- a/scripts/ct.yaml
+++ b/scripts/ct.yaml
@@ -3,6 +3,9 @@ target-branch: master
 chart-dirs:
   - stable
   - incubator
+# Deprecated and unmaintained
+excluded-charts:
+  - opa
 chart-repos:
   - "jetstack=https://charts.jetstack.io"
   - "fairwinds-stable=https://charts.fairwinds.com/stable"

--- a/stable/goldilocks/Chart.yaml
+++ b/stable/goldilocks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "v4.14.1"
-version: 10.4.1
+version: 10.5.0
 kubeVersion: ">= 1.22.0-0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -63,79 +63,79 @@ This will completely remove the VPA and then re-install it using the new method.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| uninstallVPA | bool | `false` | Enabling this flag will remove a vpa installation that was previously managed with this chart. It is considered deprecated and will be removed in a later release. |
-| vpa.enabled | bool | `false` | If true, the vpa will be installed as a sub-chart |
-| vpa.updater.enabled | bool | `false` |  |
-| metrics-server.enabled | bool | `false` | If true, the metrics-server will be installed as a sub-chart |
-| metrics-server.apiService.create | bool | `true` |  |
-| image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/goldilocks"` | Repository for the goldilocks image |
-| image.tag | string | `"v4.14.1"` | The goldilocks image tag to use |
-| image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as `Always` |
-| imagePullSecrets | list | `[]` | A list of image pull secret names to use |
-| nameOverride | string | `""` |  |
-| fullnameOverride | string | `""` |  |
+| controller.affinity | object | `{}` | Affinity for the controller pods |
+| controller.deployment.additionalLabels | object | `{}` | Extra labels for the controller deployment |
+| controller.deployment.annotations | object | `{}` | Extra annotations for the controller deployment |
+| controller.deployment.extraVolumeMounts | list | `[]` | Extra volume mounts for the controller container |
+| controller.deployment.extraVolumes | list | `[]` | Extra volumes for the controller pod |
+| controller.deployment.podAnnotations | object | `{}` | Extra annotations for the controller pod |
 | controller.enabled | bool | `true` | Whether or not to install the controller deployment |
-| controller.revisionHistoryLimit | int | `10` | Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
-| controller.rbac.create | bool | `true` | If set to true, rbac resources will be created for the controller |
-| controller.rbac.enableArgoproj | bool | `true` | If set to true, the clusterrole will give access to argoproj.io resources |
-| controller.rbac.extraRules | list | `[]` | Extra rbac rules for the controller clusterrole |
-| controller.rbac.extraClusterRoleBindings | list | `[]` | A list of ClusterRoles for which ClusterRoleBindings will be created for the ServiceAccount, if enabled |
-| controller.serviceAccount.create | bool | `true` | If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name` |
-| controller.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `controller.serviceAccount.create` |
 | controller.flags | object | `{}` | A map of additional flags to pass to the controller. For monitoring all namespaces out of the box, add the following flag "on-by-default: true" |
 | controller.logVerbosity | string | `"2"` | Controller log verbosity. Can be set from 1-10 with 10 being extremely verbose |
 | controller.nodeSelector | object | `{}` | Node selector for the controller pod |
-| controller.tolerations | list | `[]` | Tolerations for the controller pod |
-| controller.affinity | object | `{}` | Affinity for the controller pods |
-| controller.topologySpreadConstraints | list | `[]` | Topology spread constraints for the controller pods |
-| controller.resources | object | `{"limits":{},"requests":{"cpu":"25m","memory":"256Mi"}}` | The resources block for the controller pods |
 | controller.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Defines the podSecurityContext for the controller pod |
+| controller.rbac.create | bool | `true` | If set to true, rbac resources will be created for the controller |
+| controller.rbac.enableArgoproj | bool | `true` | If set to true, the clusterrole will give access to argoproj.io resources |
+| controller.rbac.extraClusterRoleBindings | list | `[]` | A list of ClusterRoles for which ClusterRoleBindings will be created for the ServiceAccount, if enabled |
+| controller.rbac.extraRules | list | `[]` | Extra rbac rules for the controller clusterrole |
+| controller.resources | object | `{"limits":{},"requests":{"cpu":"25m","memory":"256Mi"}}` | The resources block for the controller pods |
+| controller.revisionHistoryLimit | int | `10` | Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
 | controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the controller container |
-| controller.deployment.extraVolumeMounts | list | `[]` | Extra volume mounts for the controller container |
-| controller.deployment.extraVolumes | list | `[]` | Extra volumes for the controller pod |
-| controller.deployment.annotations | object | `{}` | Extra annotations for the controller deployment |
-| controller.deployment.additionalLabels | object | `{}` | Extra labels for the controller deployment |
-| controller.deployment.podAnnotations | object | `{}` | Extra annotations for the controller pod |
+| controller.serviceAccount.create | bool | `true` | If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name` |
+| controller.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `controller.serviceAccount.create` |
+| controller.tolerations | list | `[]` | Tolerations for the controller pod |
+| controller.topologySpreadConstraints | list | `[]` | Topology spread constraints for the controller pods |
+| dashboard.affinity | object | `{}` |  |
 | dashboard.basePath | string | `nil` | Path on which the dashboard is served. Defaults to `/` |
-| dashboard.enabled | bool | `true` | If true, the dashboard component will be installed |
-| dashboard.revisionHistoryLimit | int | `10` | Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
-| dashboard.replicaCount | int | `2` | Number of dashboard pods to run |
-| dashboard.service.type | string | `"ClusterIP"` | The type of the dashboard service |
-| dashboard.service.port | int | `80` | The port to run the dashboard service on |
-| dashboard.service.annotations | object | `{}` | Extra annotations for the dashboard service |
-| dashboard.flags | object | `{}` | A map of additional flags to pass to the dashboard. For monitoring all namespaces out of the box, add the following flag "on-by-default: true". |
-| dashboard.logVerbosity | string | `"2"` | Dashboard log verbosity. Can be set from 1-10 with 10 being extremely verbose |
-| dashboard.excludeContainers | string | `"linkerd-proxy,istio-proxy"` | Container names to exclude from displaying in the Goldilocks dashboard |
-| dashboard.rbac.create | bool | `true` | If set to true, rbac resources will be created for the dashboard |
-| dashboard.rbac.enableArgoproj | bool | `true` | If set to true, the clusterrole will give access to argoproj.io resources |
-| dashboard.rbac.extraRules | list | `[]` |  |
-| dashboard.rbac.extraClusterRoleBindings | list | `[]` |  |
-| dashboard.serviceAccount.create | bool | `true` | If true, a service account will be created for the dashboard. If set to false, you must set `dashboard.serviceAccount.name` |
-| dashboard.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `dashboard.serviceAccount.create` |
-| dashboard.deployment.annotations | object | `{}` | Extra annotations for the dashboard deployment |
 | dashboard.deployment.additionalLabels | object | `{}` | Extra labels for the dashboard deployment |
+| dashboard.deployment.annotations | object | `{}` | Extra annotations for the dashboard deployment |
 | dashboard.deployment.extraVolumeMounts | list | `[]` | Extra volume mounts for the dashboard container |
 | dashboard.deployment.extraVolumes | list | `[]` | Extra volumes for the dashboard pod |
 | dashboard.deployment.podAnnotations | object | `{}` | Extra annotations for the dashboard pod |
-| dashboard.ingress.enabled | bool | `false` | Enables an ingress object for the dashboard. |
-| dashboard.ingress.ingressClassName | string | `nil` | From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation. |
+| dashboard.enabled | bool | `true` | If true, the dashboard component will be installed |
+| dashboard.excludeContainers | string | `"linkerd-proxy,istio-proxy"` | Container names to exclude from displaying in the Goldilocks dashboard |
+| dashboard.flags | object | `{}` | A map of additional flags to pass to the dashboard. For monitoring all namespaces out of the box, add the following flag "on-by-default: true". |
+| dashboard.healthCheckPolicy.enabled | bool | `false` | Enables a GKE HealthCheckPolicy for the dashboard service. Only applicable when using GKE Gateway API (httpRoute.enabled: true). Required because the dashboard returns 301 on `/`, which GKE LB treats as unhealthy. |
+| dashboard.healthCheckPolicy.requestPath | string | `"/health"` | The path the GKE load balancer health check will use |
+| dashboard.httpRoute.annotations | object | `{}` | Extra annotations for the HTTPRoute |
+| dashboard.httpRoute.enabled | bool | `false` | Enables an HTTPRoute object for the dashboard (Gateway API). |
+| dashboard.httpRoute.hostnames | list | `[]` | Hostnames for the HTTPRoute |
+| dashboard.httpRoute.labels | object | `{}` | Extra labels for the HTTPRoute |
+| dashboard.httpRoute.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | Matching rules for the HTTPRoute |
+| dashboard.httpRoute.parentRefs | list | `[]` | Parent references for the HTTPRoute (required when enabled) |
 | dashboard.ingress.annotations | object | `{}` |  |
+| dashboard.ingress.enabled | bool | `false` | Enables an ingress object for the dashboard. |
 | dashboard.ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | dashboard.ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | dashboard.ingress.hosts[0].paths[0].type | string | `"ImplementationSpecific"` |  |
+| dashboard.ingress.ingressClassName | string | `nil` | From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation. |
 | dashboard.ingress.tls | list | `[]` |  |
-| dashboard.healthCheckPolicy.enabled | bool | `false` | Enables a GKE HealthCheckPolicy for the dashboard service. Only applicable when using GKE Gateway API (httpRoute.enabled: true). Required because the dashboard returns 301 on `/`, which GKE LB treats as unhealthy. |
-| dashboard.healthCheckPolicy.requestPath | string | `"/health"` | The path the GKE load balancer health check will use |
-| dashboard.httpRoute.enabled | bool | `false` | Enables an HTTPRoute object for the dashboard (Gateway API). |
-| dashboard.httpRoute.annotations | object | `{}` | Extra annotations for the HTTPRoute |
-| dashboard.httpRoute.labels | object | `{}` | Extra labels for the HTTPRoute |
-| dashboard.httpRoute.parentRefs | list | `[]` | Parent references for the HTTPRoute (required when enabled) |
-| dashboard.httpRoute.hostnames | list | `[]` | Hostnames for the HTTPRoute |
-| dashboard.httpRoute.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | Matching rules for the HTTPRoute |
-| dashboard.resources | object | `{"limits":{},"requests":{"cpu":"25m","memory":"256Mi"}}` | A resources block for the dashboard. |
-| dashboard.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Defines the podSecurityContext for the dashboard pod |
-| dashboard.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the dashboard container |
+| dashboard.logVerbosity | string | `"2"` | Dashboard log verbosity. Can be set from 1-10 with 10 being extremely verbose |
 | dashboard.nodeSelector | object | `{}` |  |
+| dashboard.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Defines the podSecurityContext for the dashboard pod |
+| dashboard.rbac.create | bool | `true` | If set to true, rbac resources will be created for the dashboard |
+| dashboard.rbac.enableArgoproj | bool | `true` | If set to true, the clusterrole will give access to argoproj.io resources |
+| dashboard.rbac.extraClusterRoleBindings | list | `[]` |  |
+| dashboard.rbac.extraRules | list | `[]` |  |
+| dashboard.replicaCount | int | `2` | Number of dashboard pods to run |
+| dashboard.resources | object | `{"limits":{},"requests":{"cpu":"25m","memory":"256Mi"}}` | A resources block for the dashboard. |
+| dashboard.revisionHistoryLimit | int | `10` | Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
+| dashboard.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the dashboard container |
+| dashboard.service.annotations | object | `{}` | Extra annotations for the dashboard service |
+| dashboard.service.port | int | `80` | The port to run the dashboard service on |
+| dashboard.service.type | string | `"ClusterIP"` | The type of the dashboard service |
+| dashboard.serviceAccount.create | bool | `true` | If true, a service account will be created for the dashboard. If set to false, you must set `dashboard.serviceAccount.name` |
+| dashboard.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `dashboard.serviceAccount.create` |
 | dashboard.tolerations | list | `[]` |  |
-| dashboard.affinity | object | `{}` |  |
 | dashboard.topologySpreadConstraints | list | `[]` | Topology spread constraints for the dashboard pods |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as `Always` |
+| image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/goldilocks"` | Repository for the goldilocks image |
+| image.tag | string | `"v4.14.1"` | The goldilocks image tag to use |
+| imagePullSecrets | list | `[]` | A list of image pull secret names to use |
+| metrics-server.apiService.create | bool | `true` |  |
+| metrics-server.enabled | bool | `false` | If true, the metrics-server will be installed as a sub-chart |
+| nameOverride | string | `""` |  |
+| uninstallVPA | bool | `false` | Enabling this flag will remove a vpa installation that was previously managed with this chart. It is considered deprecated and will be removed in a later release. |
+| vpa.enabled | bool | `false` | If true, the vpa will be installed as a sub-chart |
+| vpa.updater.enabled | bool | `false` |  |

--- a/stable/goldilocks/README.md
+++ b/stable/goldilocks/README.md
@@ -63,79 +63,79 @@ This will completely remove the VPA and then re-install it using the new method.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| controller.affinity | object | `{}` | Affinity for the controller pods |
-| controller.deployment.additionalLabels | object | `{}` | Extra labels for the controller deployment |
-| controller.deployment.annotations | object | `{}` | Extra annotations for the controller deployment |
-| controller.deployment.extraVolumeMounts | list | `[]` | Extra volume mounts for the controller container |
-| controller.deployment.extraVolumes | list | `[]` | Extra volumes for the controller pod |
-| controller.deployment.podAnnotations | object | `{}` | Extra annotations for the controller pod |
-| controller.enabled | bool | `true` | Whether or not to install the controller deployment |
-| controller.flags | object | `{}` | A map of additional flags to pass to the controller. For monitoring all namespaces out of the box, add the following flag "on-by-default: true" |
-| controller.logVerbosity | string | `"2"` | Controller log verbosity. Can be set from 1-10 with 10 being extremely verbose |
-| controller.nodeSelector | object | `{}` | Node selector for the controller pod |
-| controller.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Defines the podSecurityContext for the controller pod |
-| controller.rbac.create | bool | `true` | If set to true, rbac resources will be created for the controller |
-| controller.rbac.enableArgoproj | bool | `true` | If set to true, the clusterrole will give access to argoproj.io resources |
-| controller.rbac.extraClusterRoleBindings | list | `[]` | A list of ClusterRoles for which ClusterRoleBindings will be created for the ServiceAccount, if enabled |
-| controller.rbac.extraRules | list | `[]` | Extra rbac rules for the controller clusterrole |
-| controller.resources | object | `{"limits":{},"requests":{"cpu":"25m","memory":"256Mi"}}` | The resources block for the controller pods |
-| controller.revisionHistoryLimit | int | `10` | Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
-| controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the controller container |
-| controller.serviceAccount.create | bool | `true` | If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name` |
-| controller.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `controller.serviceAccount.create` |
-| controller.tolerations | list | `[]` | Tolerations for the controller pod |
-| controller.topologySpreadConstraints | list | `[]` | Topology spread constraints for the controller pods |
-| dashboard.affinity | object | `{}` |  |
-| dashboard.basePath | string | `nil` | Path on which the dashboard is served. Defaults to `/` |
-| dashboard.deployment.additionalLabels | object | `{}` | Extra labels for the dashboard deployment |
-| dashboard.deployment.annotations | object | `{}` | Extra annotations for the dashboard deployment |
-| dashboard.deployment.extraVolumeMounts | list | `[]` | Extra volume mounts for the dashboard container |
-| dashboard.deployment.extraVolumes | list | `[]` | Extra volumes for the dashboard pod |
-| dashboard.deployment.podAnnotations | object | `{}` | Extra annotations for the dashboard pod |
-| dashboard.enabled | bool | `true` | If true, the dashboard component will be installed |
-| dashboard.excludeContainers | string | `"linkerd-proxy,istio-proxy"` | Container names to exclude from displaying in the Goldilocks dashboard |
-| dashboard.flags | object | `{}` | A map of additional flags to pass to the dashboard. For monitoring all namespaces out of the box, add the following flag "on-by-default: true". |
-| dashboard.healthCheckPolicy.enabled | bool | `false` | Enables a GKE HealthCheckPolicy for the dashboard service. Only applicable when using GKE Gateway API (httpRoute.enabled: true). Required because the dashboard returns 301 on `/`, which GKE LB treats as unhealthy. |
-| dashboard.healthCheckPolicy.requestPath | string | `"/health"` | The path the GKE load balancer health check will use |
-| dashboard.httpRoute.annotations | object | `{}` | Extra annotations for the HTTPRoute |
-| dashboard.httpRoute.enabled | bool | `false` | Enables an HTTPRoute object for the dashboard (Gateway API). |
-| dashboard.httpRoute.hostnames | list | `[]` | Hostnames for the HTTPRoute |
-| dashboard.httpRoute.labels | object | `{}` | Extra labels for the HTTPRoute |
-| dashboard.httpRoute.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | Matching rules for the HTTPRoute |
-| dashboard.httpRoute.parentRefs | list | `[]` | Parent references for the HTTPRoute (required when enabled) |
-| dashboard.ingress.annotations | object | `{}` |  |
-| dashboard.ingress.enabled | bool | `false` | Enables an ingress object for the dashboard. |
-| dashboard.ingress.hosts[0].host | string | `"chart-example.local"` |  |
-| dashboard.ingress.hosts[0].paths[0].path | string | `"/"` |  |
-| dashboard.ingress.hosts[0].paths[0].type | string | `"ImplementationSpecific"` |  |
-| dashboard.ingress.ingressClassName | string | `nil` | From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation. |
-| dashboard.ingress.tls | list | `[]` |  |
-| dashboard.logVerbosity | string | `"2"` | Dashboard log verbosity. Can be set from 1-10 with 10 being extremely verbose |
-| dashboard.nodeSelector | object | `{}` |  |
-| dashboard.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Defines the podSecurityContext for the dashboard pod |
-| dashboard.rbac.create | bool | `true` | If set to true, rbac resources will be created for the dashboard |
-| dashboard.rbac.enableArgoproj | bool | `true` | If set to true, the clusterrole will give access to argoproj.io resources |
-| dashboard.rbac.extraClusterRoleBindings | list | `[]` |  |
-| dashboard.rbac.extraRules | list | `[]` |  |
-| dashboard.replicaCount | int | `2` | Number of dashboard pods to run |
-| dashboard.resources | object | `{"limits":{},"requests":{"cpu":"25m","memory":"256Mi"}}` | A resources block for the dashboard. |
-| dashboard.revisionHistoryLimit | int | `10` | Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
-| dashboard.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the dashboard container |
-| dashboard.service.annotations | object | `{}` | Extra annotations for the dashboard service |
-| dashboard.service.port | int | `80` | The port to run the dashboard service on |
-| dashboard.service.type | string | `"ClusterIP"` | The type of the dashboard service |
-| dashboard.serviceAccount.create | bool | `true` | If true, a service account will be created for the dashboard. If set to false, you must set `dashboard.serviceAccount.name` |
-| dashboard.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `dashboard.serviceAccount.create` |
-| dashboard.tolerations | list | `[]` |  |
-| dashboard.topologySpreadConstraints | list | `[]` | Topology spread constraints for the dashboard pods |
-| fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as `Always` |
-| image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/goldilocks"` | Repository for the goldilocks image |
-| image.tag | string | `"v4.14.1"` | The goldilocks image tag to use |
-| imagePullSecrets | list | `[]` | A list of image pull secret names to use |
-| metrics-server.apiService.create | bool | `true` |  |
-| metrics-server.enabled | bool | `false` | If true, the metrics-server will be installed as a sub-chart |
-| nameOverride | string | `""` |  |
 | uninstallVPA | bool | `false` | Enabling this flag will remove a vpa installation that was previously managed with this chart. It is considered deprecated and will be removed in a later release. |
 | vpa.enabled | bool | `false` | If true, the vpa will be installed as a sub-chart |
 | vpa.updater.enabled | bool | `false` |  |
+| metrics-server.enabled | bool | `false` | If true, the metrics-server will be installed as a sub-chart |
+| metrics-server.apiService.create | bool | `true` |  |
+| image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/goldilocks"` | Repository for the goldilocks image |
+| image.tag | string | `"v4.14.1"` | The goldilocks image tag to use |
+| image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as `Always` |
+| imagePullSecrets | list | `[]` | A list of image pull secret names to use |
+| nameOverride | string | `""` |  |
+| fullnameOverride | string | `""` |  |
+| controller.enabled | bool | `true` | Whether or not to install the controller deployment |
+| controller.revisionHistoryLimit | int | `10` | Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
+| controller.rbac.create | bool | `true` | If set to true, rbac resources will be created for the controller |
+| controller.rbac.enableArgoproj | bool | `true` | If set to true, the clusterrole will give access to argoproj.io resources |
+| controller.rbac.extraRules | list | `[]` | Extra rbac rules for the controller clusterrole |
+| controller.rbac.extraClusterRoleBindings | list | `[]` | A list of ClusterRoles for which ClusterRoleBindings will be created for the ServiceAccount, if enabled |
+| controller.serviceAccount.create | bool | `true` | If true, a service account will be created for the controller. If set to false, you must set `controller.serviceAccount.name` |
+| controller.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `controller.serviceAccount.create` |
+| controller.flags | object | `{}` | A map of additional flags to pass to the controller. For monitoring all namespaces out of the box, add the following flag "on-by-default: true" |
+| controller.logVerbosity | string | `"2"` | Controller log verbosity. Can be set from 1-10 with 10 being extremely verbose |
+| controller.nodeSelector | object | `{}` | Node selector for the controller pod |
+| controller.tolerations | list | `[]` | Tolerations for the controller pod |
+| controller.affinity | object | `{}` | Affinity for the controller pods |
+| controller.topologySpreadConstraints | list | `[]` | Topology spread constraints for the controller pods |
+| controller.resources | object | `{"limits":{},"requests":{"cpu":"25m","memory":"256Mi"}}` | The resources block for the controller pods |
+| controller.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Defines the podSecurityContext for the controller pod |
+| controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the controller container |
+| controller.deployment.extraVolumeMounts | list | `[]` | Extra volume mounts for the controller container |
+| controller.deployment.extraVolumes | list | `[]` | Extra volumes for the controller pod |
+| controller.deployment.annotations | object | `{}` | Extra annotations for the controller deployment |
+| controller.deployment.additionalLabels | object | `{}` | Extra labels for the controller deployment |
+| controller.deployment.podAnnotations | object | `{}` | Extra annotations for the controller pod |
+| dashboard.basePath | string | `nil` | Path on which the dashboard is served. Defaults to `/` |
+| dashboard.enabled | bool | `true` | If true, the dashboard component will be installed |
+| dashboard.revisionHistoryLimit | int | `10` | Number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
+| dashboard.replicaCount | int | `2` | Number of dashboard pods to run |
+| dashboard.service.type | string | `"ClusterIP"` | The type of the dashboard service |
+| dashboard.service.port | int | `80` | The port to run the dashboard service on |
+| dashboard.service.annotations | object | `{}` | Extra annotations for the dashboard service |
+| dashboard.flags | object | `{}` | A map of additional flags to pass to the dashboard. For monitoring all namespaces out of the box, add the following flag "on-by-default: true". |
+| dashboard.logVerbosity | string | `"2"` | Dashboard log verbosity. Can be set from 1-10 with 10 being extremely verbose |
+| dashboard.excludeContainers | string | `"linkerd-proxy,istio-proxy"` | Container names to exclude from displaying in the Goldilocks dashboard |
+| dashboard.rbac.create | bool | `true` | If set to true, rbac resources will be created for the dashboard |
+| dashboard.rbac.enableArgoproj | bool | `true` | If set to true, the clusterrole will give access to argoproj.io resources |
+| dashboard.rbac.extraRules | list | `[]` |  |
+| dashboard.rbac.extraClusterRoleBindings | list | `[]` |  |
+| dashboard.serviceAccount.create | bool | `true` | If true, a service account will be created for the dashboard. If set to false, you must set `dashboard.serviceAccount.name` |
+| dashboard.serviceAccount.name | string | `nil` | The name of an existing service account to use for the controller. Combined with `dashboard.serviceAccount.create` |
+| dashboard.deployment.annotations | object | `{}` | Extra annotations for the dashboard deployment |
+| dashboard.deployment.additionalLabels | object | `{}` | Extra labels for the dashboard deployment |
+| dashboard.deployment.extraVolumeMounts | list | `[]` | Extra volume mounts for the dashboard container |
+| dashboard.deployment.extraVolumes | list | `[]` | Extra volumes for the dashboard pod |
+| dashboard.deployment.podAnnotations | object | `{}` | Extra annotations for the dashboard pod |
+| dashboard.ingress.enabled | bool | `false` | Enables an ingress object for the dashboard. |
+| dashboard.ingress.ingressClassName | string | `nil` | From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation. |
+| dashboard.ingress.annotations | object | `{}` |  |
+| dashboard.ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| dashboard.ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| dashboard.ingress.hosts[0].paths[0].type | string | `"ImplementationSpecific"` |  |
+| dashboard.ingress.tls | list | `[]` |  |
+| dashboard.healthCheckPolicy.enabled | bool | `false` | Enables a GKE HealthCheckPolicy for the dashboard service. Only applicable when using GKE Gateway API (httpRoute.enabled: true). Required because the dashboard returns 301 on `/`, which GKE LB treats as unhealthy. |
+| dashboard.healthCheckPolicy.requestPath | string | `"/health"` | The path the GKE load balancer health check will use |
+| dashboard.httpRoute.enabled | bool | `false` | Enables an HTTPRoute object for the dashboard (Gateway API). |
+| dashboard.httpRoute.annotations | object | `{}` | Extra annotations for the HTTPRoute |
+| dashboard.httpRoute.labels | object | `{}` | Extra labels for the HTTPRoute |
+| dashboard.httpRoute.parentRefs | list | `[]` | Parent references for the HTTPRoute (required when enabled) |
+| dashboard.httpRoute.hostnames | list | `[]` | Hostnames for the HTTPRoute |
+| dashboard.httpRoute.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | Matching rules for the HTTPRoute |
+| dashboard.resources | object | `{"limits":{},"requests":{"cpu":"25m","memory":"256Mi"}}` | A resources block for the dashboard. |
+| dashboard.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Defines the podSecurityContext for the dashboard pod |
+| dashboard.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The container securityContext for the dashboard container |
+| dashboard.nodeSelector | object | `{}` |  |
+| dashboard.tolerations | list | `[]` |  |
+| dashboard.affinity | object | `{}` |  |
+| dashboard.topologySpreadConstraints | list | `[]` | Topology spread constraints for the dashboard pods |

--- a/stable/goldilocks/templates/vpa-uninstall-hook.yaml
+++ b/stable/goldilocks/templates/vpa-uninstall-hook.yaml
@@ -62,7 +62,7 @@ spec:
       serviceAccountName: {{ include "goldilocks.fullname" . }}-vpa-uninstall
       containers:
       - name: vpa-uninstall
-        image: quay.io/reactiveops/ci-images:v9-alpine
+        image: us-docker.pkg.dev/fairwinds-ops/oss/ci-images:v9-alpine
         command: ["bash"]
         args:
           - -c

--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.12.4
+version: 4.12.5
 appVersion: 1.6.0
 maintainers:
   - name: sudermanjr

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -169,110 +169,110 @@ For more information, see [VPA docs](https://github.com/kubernetes/autoscaler/bl
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| admissionController.affinity | object | `{}` |  |
-| admissionController.annotations | object | `{}` | Annotations to add to the admission controller deployment |
-| admissionController.certGen.affinity | object | `{}` |  |
-| admissionController.certGen.env | object | `{}` | Additional environment variables to be added to the certgen container. Format is KEY: Value format |
-| admissionController.certGen.image.pullPolicy | string | `"Always"` | The pull policy for the certgen image. Recommend not changing this |
-| admissionController.certGen.image.repository | string | `"registry.k8s.io/ingress-nginx/kube-webhook-certgen"` | An image that contains certgen for creating certificates. Only used if admissionController.generateCertificate is true |
-| admissionController.certGen.image.tag | string | `"v20230312-helm-chart-4.5.2-28-g66a760794"` | An image tag for the admissionController.certGen.image.repository image. Only used if admissionController.generateCertificate is true |
-| admissionController.certGen.nodeSelector | object | `{}` |  |
-| admissionController.certGen.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The securityContext block for the certgen pod(s) |
-| admissionController.certGen.resources | object | `{}` | The resources block for the certgen pod |
-| admissionController.certGen.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The securityContext block for the certgen container(s) |
-| admissionController.certGen.tolerations | list | `[]` |  |
+| imagePullSecrets | list | `[]` | A list of image pull secrets to be used for all pods |
+| priorityClassName | string | `""` | To set the priorityclass for all pods |
+| nameOverride | string | `""` | A template override for the name |
+| fullnameOverride | string | `""` | A template override for the fullname |
+| podLabels | object | `{}` | Labels to add to all pods |
+| rbac.create | bool | `true` | If true, then rbac resources (ClusterRoles and ClusterRoleBindings) will be created for the selected components. Temporary rbac resources will still be created, to ensure a functioning installation process |
+| rbac.extraRules | object | `{"vpaActor":[],"vpaCheckpointActor":[],"vpaEvictioner":[],"vpaMetricsReader":[],"vpaStatusActor":[],"vpaStatusReader":[],"vpaTargetReader":[],"vpaUpdaterInPlace":[]}` | Extra rbac rules for ClusterRoles |
+| rbac.extraRules.vpaActor | list | `[]` | Extra rbac rules for the vpa-actor ClusterRole |
+| rbac.extraRules.vpaStatusActor | list | `[]` | Extra rbac rules for the vpa-status-actor ClusterRole |
+| rbac.extraRules.vpaCheckpointActor | list | `[]` | Extra rbac rules for the vpa-checkpoint-actor ClusterRole |
+| rbac.extraRules.vpaEvictioner | list | `[]` | Extra rbac rules for the vpa-evictioner ClusterRole |
+| rbac.extraRules.vpaMetricsReader | list | `[]` | Extra rbac rules for the vpa-metrics-reader ClusterRole |
+| rbac.extraRules.vpaUpdaterInPlace | list | `[]` | Extra rbac rules for the vpa-updater-in-place ClusterRole |
+| rbac.extraRules.vpaTargetReader | list | `[]` | Extra rbac rules for the vpa-target-reader ClusterRole |
+| rbac.extraRules.vpaStatusReader | list | `[]` | Extra rbac rules for the vpa-status-reader ClusterRole |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created for each component |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service accounts for each component |
+| serviceAccount.name | string | `""` | The base name of the service account to use (appended with the component). If not set and create is true, a name is generated using the fullname template and appended for each component |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
+| recommender.enabled | bool | `true` | If true, the vpa recommender component will be installed. |
+| recommender.envFromSecret | string | `""` | Specify a secret to get environment variables from |
+| recommender.annotations | object | `{}` | Annotations to add to the recommender deployment |
+| recommender.extraArgs | object | `{"pod-recommendation-min-cpu-millicores":15,"pod-recommendation-min-memory-mb":100,"v":"4"}` | A set of key-value flags to be passed to the recommender |
+| recommender.replicaCount | int | `1` |  |
+| recommender.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
+| recommender.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
+| recommender.image.repository | string | `"registry.k8s.io/autoscaling/vpa-recommender"` | The location of the recommender image |
+| recommender.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| recommender.image.pullPolicy | string | `"Always"` | The pull policy for the recommender image. Recommend not changing this |
+| recommender.podAnnotations | object | `{}` | Annotations to add to the recommender pod |
+| recommender.podLabels | object | `{}` | Labels to add to the recommender pod |
+| recommender.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The security context for the recommender pod |
+| recommender.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for the containers inside the recommender pod |
+| recommender.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the recommender pod |
+| recommender.readinessProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The readiness probe definition inside the recommender pod |
+| recommender.resources | object | `{"limits":{},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the recommender pod |
+| recommender.nodeSelector | object | `{}` |  |
+| recommender.tolerations | list | `[]` |  |
+| recommender.affinity | object | `{}` |  |
+| recommender.podMonitor | object | `{"annotations":{},"enabled":false,"labels":{}}` | Enables a prometheus operator podMonitor for the recommender |
+| updater.enabled | bool | `true` | If true, the updater component will be deployed |
+| updater.annotations | object | `{}` | Annotations to add to the updater deployment |
+| updater.extraArgs | object | `{}` | A key-value map of flags to pass to the updater. Since VPA 1.6.0: set "in-place-skip-disruption-budget": "true" to skip PDB checks for in-place updates when all containers have NotRequired resize policy. |
+| updater.replicaCount | int | `1` |  |
+| updater.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
+| updater.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
+| updater.image.repository | string | `"registry.k8s.io/autoscaling/vpa-updater"` | The location of the updater image |
+| updater.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| updater.image.pullPolicy | string | `"Always"` | The pull policy for the updater image. Recommend not changing this |
+| updater.podAnnotations | object | `{}` | Annotations to add to the updater pod |
+| updater.podLabels | object | `{}` | Labels to add to the updater pod |
+| updater.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The security context for the updater pod |
+| updater.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for the containers inside the updater pod |
+| updater.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the updater pod |
+| updater.readinessProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The readiness probe definition inside the updater pod |
+| updater.resources | object | `{"limits":{},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the updater pod |
+| updater.nodeSelector | object | `{}` |  |
+| updater.tolerations | list | `[]` |  |
+| updater.affinity | object | `{}` |  |
+| updater.podMonitor | object | `{"annotations":{},"enabled":false,"labels":{}}` | Enables a prometheus operator podMonitor for the updater |
 | admissionController.enabled | bool | `true` | If true, will install the admission-controller component of vpa |
+| admissionController.annotations | object | `{}` | Annotations to add to the admission controller deployment |
 | admissionController.extraArgs | object | `{}` | A key-value map of flags to pass to the admissionController |
 | admissionController.generateCertificate | bool | `true` | If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook |
-| admissionController.httpPort | int | `8000` | Port of the admission controller for the mutating webhooks |
-| admissionController.image.pullPolicy | string | `"Always"` | The pull policy for the admission controller image. Recommend not changing this |
-| admissionController.image.repository | string | `"registry.k8s.io/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
-| admissionController.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
-| admissionController.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the admission controller pod |
-| admissionController.metricsPort | int | `8944` | Port of the admission controller where metrics can be received from |
+| admissionController.secretName | string | `"{{ include \"vpa.fullname\" . }}-tls-secret"` | Name for the TLS secret created for the webhook. Default {{ .Release.Name }}-tls-secret |
+| admissionController.registerWebhook | bool | `false` | If true, will allow the vpa admission controller to register itself as a mutating webhook |
+| admissionController.certGen.image.repository | string | `"registry.k8s.io/ingress-nginx/kube-webhook-certgen"` | An image that contains certgen for creating certificates. Only used if admissionController.generateCertificate is true |
+| admissionController.certGen.image.tag | string | `"v20230312-helm-chart-4.5.2-28-g66a760794"` | An image tag for the admissionController.certGen.image.repository image. Only used if admissionController.generateCertificate is true |
+| admissionController.certGen.image.pullPolicy | string | `"Always"` | The pull policy for the certgen image. Recommend not changing this |
+| admissionController.certGen.env | object | `{}` | Additional environment variables to be added to the certgen container. Format is KEY: Value format |
+| admissionController.certGen.resources | object | `{}` | The resources block for the certgen pod |
+| admissionController.certGen.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The securityContext block for the certgen pod(s) |
+| admissionController.certGen.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The securityContext block for the certgen container(s) |
+| admissionController.certGen.nodeSelector | object | `{}` |  |
+| admissionController.certGen.tolerations | list | `[]` |  |
+| admissionController.certGen.affinity | object | `{}` |  |
 | admissionController.mutatingWebhookConfiguration.annotations | object | `{}` | Additional annotations for the MutatingWebhookConfiguration. Can be used for integration with cert-manager |
 | admissionController.mutatingWebhookConfiguration.failurePolicy | string | `"Ignore"` | The failurePolicy for the mutating webhook. Allowed values are: Ignore, Fail |
 | admissionController.mutatingWebhookConfiguration.namespaceSelector | object | `{}` | The namespaceSelector controls, which namespaces are affected by the webhook |
 | admissionController.mutatingWebhookConfiguration.objectSelector | object | `{}` | The objectSelector can filter object on e.g. labels |
 | admissionController.mutatingWebhookConfiguration.timeoutSeconds | int | `5` |  |
-| admissionController.nodeSelector | object | `{}` |  |
-| admissionController.podAnnotations | object | `{}` | Annotations to add to the admission controller pod |
+| admissionController.replicaCount | int | `1` |  |
+| admissionController.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
 | admissionController.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
+| admissionController.image.repository | string | `"registry.k8s.io/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
+| admissionController.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| admissionController.image.pullPolicy | string | `"Always"` | The pull policy for the admission controller image. Recommend not changing this |
+| admissionController.podAnnotations | object | `{}` | Annotations to add to the admission controller pod |
 | admissionController.podLabels | object | `{}` | Labels to add to the admission controller pod |
 | admissionController.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The security context for the admission controller pod |
-| admissionController.readinessProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The readiness probe definition inside the admission controller pod |
-| admissionController.registerWebhook | bool | `false` | If true, will allow the vpa admission controller to register itself as a mutating webhook |
-| admissionController.replicaCount | int | `1` |  |
-| admissionController.resources | object | `{"limits":{},"requests":{"cpu":"50m","memory":"200Mi"}}` | The resources block for the admission controller pod |
-| admissionController.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
-| admissionController.secretName | string | `"{{ include \"vpa.fullname\" . }}-tls-secret"` | Name for the TLS secret created for the webhook. Default {{ .Release.Name }}-tls-secret |
 | admissionController.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for the containers inside the admission controller pod |
+| admissionController.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the admission controller pod |
+| admissionController.readinessProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The readiness probe definition inside the admission controller pod |
+| admissionController.resources | object | `{"limits":{},"requests":{"cpu":"50m","memory":"200Mi"}}` | The resources block for the admission controller pod |
 | admissionController.tlsSecretKeys | list | `[]` | The keys in the vpa-tls-certs secret to map in to the admission controller |
+| admissionController.nodeSelector | object | `{}` |  |
 | admissionController.tolerations | list | `[]` |  |
+| admissionController.affinity | object | `{}` |  |
 | admissionController.useHostNetwork | bool | `false` | Whether to use host network, this is required on EKS with custom CNI |
-| fullnameOverride | string | `""` | A template override for the fullname |
-| imagePullSecrets | list | `[]` | A list of image pull secrets to be used for all pods |
-| metrics-server | object | `{"enabled":false}` | configuration options for the [metrics server Helm chart](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server). See the projects [README.md](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server#configuration) for all available options |
-| metrics-server.enabled | bool | `false` | Whether or not the metrics server Helm chart should be installed |
-| nameOverride | string | `""` | A template override for the name |
-| podLabels | object | `{}` | Labels to add to all pods |
-| priorityClassName | string | `""` | To set the priorityclass for all pods |
-| rbac.create | bool | `true` | If true, then rbac resources (ClusterRoles and ClusterRoleBindings) will be created for the selected components. Temporary rbac resources will still be created, to ensure a functioning installation process |
-| rbac.extraRules | object | `{"vpaActor":[],"vpaCheckpointActor":[],"vpaEvictioner":[],"vpaMetricsReader":[],"vpaStatusActor":[],"vpaStatusReader":[],"vpaTargetReader":[],"vpaUpdaterInPlace":[]}` | Extra rbac rules for ClusterRoles |
-| rbac.extraRules.vpaActor | list | `[]` | Extra rbac rules for the vpa-actor ClusterRole |
-| rbac.extraRules.vpaCheckpointActor | list | `[]` | Extra rbac rules for the vpa-checkpoint-actor ClusterRole |
-| rbac.extraRules.vpaEvictioner | list | `[]` | Extra rbac rules for the vpa-evictioner ClusterRole |
-| rbac.extraRules.vpaMetricsReader | list | `[]` | Extra rbac rules for the vpa-metrics-reader ClusterRole |
-| rbac.extraRules.vpaStatusActor | list | `[]` | Extra rbac rules for the vpa-status-actor ClusterRole |
-| rbac.extraRules.vpaStatusReader | list | `[]` | Extra rbac rules for the vpa-status-reader ClusterRole |
-| rbac.extraRules.vpaTargetReader | list | `[]` | Extra rbac rules for the vpa-target-reader ClusterRole |
-| rbac.extraRules.vpaUpdaterInPlace | list | `[]` | Extra rbac rules for the vpa-updater-in-place ClusterRole |
-| recommender.affinity | object | `{}` |  |
-| recommender.annotations | object | `{}` | Annotations to add to the recommender deployment |
-| recommender.enabled | bool | `true` | If true, the vpa recommender component will be installed. |
-| recommender.envFromSecret | string | `""` | Specify a secret to get environment variables from |
-| recommender.extraArgs | object | `{"pod-recommendation-min-cpu-millicores":15,"pod-recommendation-min-memory-mb":100,"v":"4"}` | A set of key-value flags to be passed to the recommender |
-| recommender.image.pullPolicy | string | `"Always"` | The pull policy for the recommender image. Recommend not changing this |
-| recommender.image.repository | string | `"registry.k8s.io/autoscaling/vpa-recommender"` | The location of the recommender image |
-| recommender.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
-| recommender.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the recommender pod |
-| recommender.nodeSelector | object | `{}` |  |
-| recommender.podAnnotations | object | `{}` | Annotations to add to the recommender pod |
-| recommender.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
-| recommender.podLabels | object | `{}` | Labels to add to the recommender pod |
-| recommender.podMonitor | object | `{"annotations":{},"enabled":false,"labels":{}}` | Enables a prometheus operator podMonitor for the recommender |
-| recommender.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The security context for the recommender pod |
-| recommender.readinessProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The readiness probe definition inside the recommender pod |
-| recommender.replicaCount | int | `1` |  |
-| recommender.resources | object | `{"limits":{},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the recommender pod |
-| recommender.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
-| recommender.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for the containers inside the recommender pod |
-| recommender.tolerations | list | `[]` |  |
-| serviceAccount.annotations | object | `{}` | Annotations to add to the service accounts for each component |
-| serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
-| serviceAccount.create | bool | `true` | Specifies whether a service account should be created for each component |
-| serviceAccount.name | string | `""` | The base name of the service account to use (appended with the component). If not set and create is true, a name is generated using the fullname template and appended for each component |
-| tests.image.pullPolicy | string | `"Always"` | The pull policy for the tests image. |
+| admissionController.httpPort | int | `8000` | Port of the admission controller for the mutating webhooks |
+| admissionController.metricsPort | int | `8944` | Port of the admission controller where metrics can be received from |
+| tests.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The security context for the containers run as helm hook tests |
 | tests.image.repository | string | `"alpine/kubectl"` | An image used for testing containing sh, cat and kubectl |
 | tests.image.tag | string | `"1.36.2"` | An image tag for the tests image |
-| tests.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The security context for the containers run as helm hook tests |
-| updater.affinity | object | `{}` |  |
-| updater.annotations | object | `{}` | Annotations to add to the updater deployment |
-| updater.enabled | bool | `true` | If true, the updater component will be deployed |
-| updater.extraArgs | object | `{}` | A key-value map of flags to pass to the updater. Since VPA 1.6.0: set "in-place-skip-disruption-budget": "true" to skip PDB checks for in-place updates when all containers have NotRequired resize policy. |
-| updater.image.pullPolicy | string | `"Always"` | The pull policy for the updater image. Recommend not changing this |
-| updater.image.repository | string | `"registry.k8s.io/autoscaling/vpa-updater"` | The location of the updater image |
-| updater.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
-| updater.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the updater pod |
-| updater.nodeSelector | object | `{}` |  |
-| updater.podAnnotations | object | `{}` | Annotations to add to the updater pod |
-| updater.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
-| updater.podLabels | object | `{}` | Labels to add to the updater pod |
-| updater.podMonitor | object | `{"annotations":{},"enabled":false,"labels":{}}` | Enables a prometheus operator podMonitor for the updater |
-| updater.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The security context for the updater pod |
-| updater.readinessProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The readiness probe definition inside the updater pod |
-| updater.replicaCount | int | `1` |  |
-| updater.resources | object | `{"limits":{},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the updater pod |
-| updater.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
-| updater.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for the containers inside the updater pod |
-| updater.tolerations | list | `[]` |  |
+| tests.image.pullPolicy | string | `"Always"` | The pull policy for the tests image. |
+| metrics-server | object | `{"enabled":false}` | configuration options for the [metrics server Helm chart](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server). See the projects [README.md](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server#configuration) for all available options |
+| metrics-server.enabled | bool | `false` | Whether or not the metrics server Helm chart should be installed |

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -104,7 +104,7 @@ In the previous version, when the admissionController.cleanupOnDelete flag was s
 cleanupOnDelete:
     enabled: true
     image:
-      repository: quay.io/reactiveops/ci-images
+      repository: us-docker.pkg.dev/fairwinds-ops/oss/ci-images
       tag: v11-alpine
 
 ```
@@ -169,110 +169,110 @@ For more information, see [VPA docs](https://github.com/kubernetes/autoscaler/bl
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| imagePullSecrets | list | `[]` | A list of image pull secrets to be used for all pods |
-| priorityClassName | string | `""` | To set the priorityclass for all pods |
-| nameOverride | string | `""` | A template override for the name |
-| fullnameOverride | string | `""` | A template override for the fullname |
-| podLabels | object | `{}` | Labels to add to all pods |
-| rbac.create | bool | `true` | If true, then rbac resources (ClusterRoles and ClusterRoleBindings) will be created for the selected components. Temporary rbac resources will still be created, to ensure a functioning installation process |
-| rbac.extraRules | object | `{"vpaActor":[],"vpaCheckpointActor":[],"vpaEvictioner":[],"vpaMetricsReader":[],"vpaStatusActor":[],"vpaStatusReader":[],"vpaTargetReader":[],"vpaUpdaterInPlace":[]}` | Extra rbac rules for ClusterRoles |
-| rbac.extraRules.vpaActor | list | `[]` | Extra rbac rules for the vpa-actor ClusterRole |
-| rbac.extraRules.vpaStatusActor | list | `[]` | Extra rbac rules for the vpa-status-actor ClusterRole |
-| rbac.extraRules.vpaCheckpointActor | list | `[]` | Extra rbac rules for the vpa-checkpoint-actor ClusterRole |
-| rbac.extraRules.vpaEvictioner | list | `[]` | Extra rbac rules for the vpa-evictioner ClusterRole |
-| rbac.extraRules.vpaMetricsReader | list | `[]` | Extra rbac rules for the vpa-metrics-reader ClusterRole |
-| rbac.extraRules.vpaUpdaterInPlace | list | `[]` | Extra rbac rules for the vpa-updater-in-place ClusterRole |
-| rbac.extraRules.vpaTargetReader | list | `[]` | Extra rbac rules for the vpa-target-reader ClusterRole |
-| rbac.extraRules.vpaStatusReader | list | `[]` | Extra rbac rules for the vpa-status-reader ClusterRole |
-| serviceAccount.create | bool | `true` | Specifies whether a service account should be created for each component |
-| serviceAccount.annotations | object | `{}` | Annotations to add to the service accounts for each component |
-| serviceAccount.name | string | `""` | The base name of the service account to use (appended with the component). If not set and create is true, a name is generated using the fullname template and appended for each component |
-| serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
-| recommender.enabled | bool | `true` | If true, the vpa recommender component will be installed. |
-| recommender.envFromSecret | string | `""` | Specify a secret to get environment variables from |
-| recommender.annotations | object | `{}` | Annotations to add to the recommender deployment |
-| recommender.extraArgs | object | `{"pod-recommendation-min-cpu-millicores":15,"pod-recommendation-min-memory-mb":100,"v":"4"}` | A set of key-value flags to be passed to the recommender |
-| recommender.replicaCount | int | `1` |  |
-| recommender.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
-| recommender.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
-| recommender.image.repository | string | `"registry.k8s.io/autoscaling/vpa-recommender"` | The location of the recommender image |
-| recommender.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
-| recommender.image.pullPolicy | string | `"Always"` | The pull policy for the recommender image. Recommend not changing this |
-| recommender.podAnnotations | object | `{}` | Annotations to add to the recommender pod |
-| recommender.podLabels | object | `{}` | Labels to add to the recommender pod |
-| recommender.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The security context for the recommender pod |
-| recommender.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for the containers inside the recommender pod |
-| recommender.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the recommender pod |
-| recommender.readinessProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The readiness probe definition inside the recommender pod |
-| recommender.resources | object | `{"limits":{},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the recommender pod |
-| recommender.nodeSelector | object | `{}` |  |
-| recommender.tolerations | list | `[]` |  |
-| recommender.affinity | object | `{}` |  |
-| recommender.podMonitor | object | `{"annotations":{},"enabled":false,"labels":{}}` | Enables a prometheus operator podMonitor for the recommender |
-| updater.enabled | bool | `true` | If true, the updater component will be deployed |
-| updater.annotations | object | `{}` | Annotations to add to the updater deployment |
-| updater.extraArgs | object | `{}` | A key-value map of flags to pass to the updater. Since VPA 1.6.0: set "in-place-skip-disruption-budget": "true" to skip PDB checks for in-place updates when all containers have NotRequired resize policy. |
-| updater.replicaCount | int | `1` |  |
-| updater.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
-| updater.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
-| updater.image.repository | string | `"registry.k8s.io/autoscaling/vpa-updater"` | The location of the updater image |
-| updater.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
-| updater.image.pullPolicy | string | `"Always"` | The pull policy for the updater image. Recommend not changing this |
-| updater.podAnnotations | object | `{}` | Annotations to add to the updater pod |
-| updater.podLabels | object | `{}` | Labels to add to the updater pod |
-| updater.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The security context for the updater pod |
-| updater.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for the containers inside the updater pod |
-| updater.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the updater pod |
-| updater.readinessProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The readiness probe definition inside the updater pod |
-| updater.resources | object | `{"limits":{},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the updater pod |
-| updater.nodeSelector | object | `{}` |  |
-| updater.tolerations | list | `[]` |  |
-| updater.affinity | object | `{}` |  |
-| updater.podMonitor | object | `{"annotations":{},"enabled":false,"labels":{}}` | Enables a prometheus operator podMonitor for the updater |
-| admissionController.enabled | bool | `true` | If true, will install the admission-controller component of vpa |
+| admissionController.affinity | object | `{}` |  |
 | admissionController.annotations | object | `{}` | Annotations to add to the admission controller deployment |
-| admissionController.extraArgs | object | `{}` | A key-value map of flags to pass to the admissionController |
-| admissionController.generateCertificate | bool | `true` | If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook |
-| admissionController.secretName | string | `"{{ include \"vpa.fullname\" . }}-tls-secret"` | Name for the TLS secret created for the webhook. Default {{ .Release.Name }}-tls-secret |
-| admissionController.registerWebhook | bool | `false` | If true, will allow the vpa admission controller to register itself as a mutating webhook |
+| admissionController.certGen.affinity | object | `{}` |  |
+| admissionController.certGen.env | object | `{}` | Additional environment variables to be added to the certgen container. Format is KEY: Value format |
+| admissionController.certGen.image.pullPolicy | string | `"Always"` | The pull policy for the certgen image. Recommend not changing this |
 | admissionController.certGen.image.repository | string | `"registry.k8s.io/ingress-nginx/kube-webhook-certgen"` | An image that contains certgen for creating certificates. Only used if admissionController.generateCertificate is true |
 | admissionController.certGen.image.tag | string | `"v20230312-helm-chart-4.5.2-28-g66a760794"` | An image tag for the admissionController.certGen.image.repository image. Only used if admissionController.generateCertificate is true |
-| admissionController.certGen.image.pullPolicy | string | `"Always"` | The pull policy for the certgen image. Recommend not changing this |
-| admissionController.certGen.env | object | `{}` | Additional environment variables to be added to the certgen container. Format is KEY: Value format |
-| admissionController.certGen.resources | object | `{}` | The resources block for the certgen pod |
-| admissionController.certGen.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The securityContext block for the certgen pod(s) |
-| admissionController.certGen.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The securityContext block for the certgen container(s) |
 | admissionController.certGen.nodeSelector | object | `{}` |  |
+| admissionController.certGen.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The securityContext block for the certgen pod(s) |
+| admissionController.certGen.resources | object | `{}` | The resources block for the certgen pod |
+| admissionController.certGen.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The securityContext block for the certgen container(s) |
 | admissionController.certGen.tolerations | list | `[]` |  |
-| admissionController.certGen.affinity | object | `{}` |  |
+| admissionController.enabled | bool | `true` | If true, will install the admission-controller component of vpa |
+| admissionController.extraArgs | object | `{}` | A key-value map of flags to pass to the admissionController |
+| admissionController.generateCertificate | bool | `true` | If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook |
+| admissionController.httpPort | int | `8000` | Port of the admission controller for the mutating webhooks |
+| admissionController.image.pullPolicy | string | `"Always"` | The pull policy for the admission controller image. Recommend not changing this |
+| admissionController.image.repository | string | `"registry.k8s.io/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
+| admissionController.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| admissionController.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the admission controller pod |
+| admissionController.metricsPort | int | `8944` | Port of the admission controller where metrics can be received from |
 | admissionController.mutatingWebhookConfiguration.annotations | object | `{}` | Additional annotations for the MutatingWebhookConfiguration. Can be used for integration with cert-manager |
 | admissionController.mutatingWebhookConfiguration.failurePolicy | string | `"Ignore"` | The failurePolicy for the mutating webhook. Allowed values are: Ignore, Fail |
 | admissionController.mutatingWebhookConfiguration.namespaceSelector | object | `{}` | The namespaceSelector controls, which namespaces are affected by the webhook |
 | admissionController.mutatingWebhookConfiguration.objectSelector | object | `{}` | The objectSelector can filter object on e.g. labels |
 | admissionController.mutatingWebhookConfiguration.timeoutSeconds | int | `5` |  |
-| admissionController.replicaCount | int | `1` |  |
-| admissionController.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
-| admissionController.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
-| admissionController.image.repository | string | `"registry.k8s.io/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |
-| admissionController.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
-| admissionController.image.pullPolicy | string | `"Always"` | The pull policy for the admission controller image. Recommend not changing this |
+| admissionController.nodeSelector | object | `{}` |  |
 | admissionController.podAnnotations | object | `{}` | Annotations to add to the admission controller pod |
+| admissionController.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
 | admissionController.podLabels | object | `{}` | Labels to add to the admission controller pod |
 | admissionController.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The security context for the admission controller pod |
-| admissionController.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for the containers inside the admission controller pod |
-| admissionController.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the admission controller pod |
 | admissionController.readinessProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The readiness probe definition inside the admission controller pod |
+| admissionController.registerWebhook | bool | `false` | If true, will allow the vpa admission controller to register itself as a mutating webhook |
+| admissionController.replicaCount | int | `1` |  |
 | admissionController.resources | object | `{"limits":{},"requests":{"cpu":"50m","memory":"200Mi"}}` | The resources block for the admission controller pod |
+| admissionController.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
+| admissionController.secretName | string | `"{{ include \"vpa.fullname\" . }}-tls-secret"` | Name for the TLS secret created for the webhook. Default {{ .Release.Name }}-tls-secret |
+| admissionController.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for the containers inside the admission controller pod |
 | admissionController.tlsSecretKeys | list | `[]` | The keys in the vpa-tls-certs secret to map in to the admission controller |
-| admissionController.nodeSelector | object | `{}` |  |
 | admissionController.tolerations | list | `[]` |  |
-| admissionController.affinity | object | `{}` |  |
 | admissionController.useHostNetwork | bool | `false` | Whether to use host network, this is required on EKS with custom CNI |
-| admissionController.httpPort | int | `8000` | Port of the admission controller for the mutating webhooks |
-| admissionController.metricsPort | int | `8944` | Port of the admission controller where metrics can be received from |
-| tests.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The security context for the containers run as helm hook tests |
-| tests.image.repository | string | `"alpine/kubectl"` | An image used for testing containing sh, cat and kubectl |
-| tests.image.tag | string | `"1.36.2"` | An image tag for the tests image |
-| tests.image.pullPolicy | string | `"Always"` | The pull policy for the tests image. |
+| fullnameOverride | string | `""` | A template override for the fullname |
+| imagePullSecrets | list | `[]` | A list of image pull secrets to be used for all pods |
 | metrics-server | object | `{"enabled":false}` | configuration options for the [metrics server Helm chart](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server). See the projects [README.md](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server#configuration) for all available options |
 | metrics-server.enabled | bool | `false` | Whether or not the metrics server Helm chart should be installed |
+| nameOverride | string | `""` | A template override for the name |
+| podLabels | object | `{}` | Labels to add to all pods |
+| priorityClassName | string | `""` | To set the priorityclass for all pods |
+| rbac.create | bool | `true` | If true, then rbac resources (ClusterRoles and ClusterRoleBindings) will be created for the selected components. Temporary rbac resources will still be created, to ensure a functioning installation process |
+| rbac.extraRules | object | `{"vpaActor":[],"vpaCheckpointActor":[],"vpaEvictioner":[],"vpaMetricsReader":[],"vpaStatusActor":[],"vpaStatusReader":[],"vpaTargetReader":[],"vpaUpdaterInPlace":[]}` | Extra rbac rules for ClusterRoles |
+| rbac.extraRules.vpaActor | list | `[]` | Extra rbac rules for the vpa-actor ClusterRole |
+| rbac.extraRules.vpaCheckpointActor | list | `[]` | Extra rbac rules for the vpa-checkpoint-actor ClusterRole |
+| rbac.extraRules.vpaEvictioner | list | `[]` | Extra rbac rules for the vpa-evictioner ClusterRole |
+| rbac.extraRules.vpaMetricsReader | list | `[]` | Extra rbac rules for the vpa-metrics-reader ClusterRole |
+| rbac.extraRules.vpaStatusActor | list | `[]` | Extra rbac rules for the vpa-status-actor ClusterRole |
+| rbac.extraRules.vpaStatusReader | list | `[]` | Extra rbac rules for the vpa-status-reader ClusterRole |
+| rbac.extraRules.vpaTargetReader | list | `[]` | Extra rbac rules for the vpa-target-reader ClusterRole |
+| rbac.extraRules.vpaUpdaterInPlace | list | `[]` | Extra rbac rules for the vpa-updater-in-place ClusterRole |
+| recommender.affinity | object | `{}` |  |
+| recommender.annotations | object | `{}` | Annotations to add to the recommender deployment |
+| recommender.enabled | bool | `true` | If true, the vpa recommender component will be installed. |
+| recommender.envFromSecret | string | `""` | Specify a secret to get environment variables from |
+| recommender.extraArgs | object | `{"pod-recommendation-min-cpu-millicores":15,"pod-recommendation-min-memory-mb":100,"v":"4"}` | A set of key-value flags to be passed to the recommender |
+| recommender.image.pullPolicy | string | `"Always"` | The pull policy for the recommender image. Recommend not changing this |
+| recommender.image.repository | string | `"registry.k8s.io/autoscaling/vpa-recommender"` | The location of the recommender image |
+| recommender.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| recommender.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the recommender pod |
+| recommender.nodeSelector | object | `{}` |  |
+| recommender.podAnnotations | object | `{}` | Annotations to add to the recommender pod |
+| recommender.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
+| recommender.podLabels | object | `{}` | Labels to add to the recommender pod |
+| recommender.podMonitor | object | `{"annotations":{},"enabled":false,"labels":{}}` | Enables a prometheus operator podMonitor for the recommender |
+| recommender.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The security context for the recommender pod |
+| recommender.readinessProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The readiness probe definition inside the recommender pod |
+| recommender.replicaCount | int | `1` |  |
+| recommender.resources | object | `{"limits":{},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the recommender pod |
+| recommender.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
+| recommender.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for the containers inside the recommender pod |
+| recommender.tolerations | list | `[]` |  |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service accounts for each component |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created for each component |
+| serviceAccount.name | string | `""` | The base name of the service account to use (appended with the component). If not set and create is true, a name is generated using the fullname template and appended for each component |
+| tests.image.pullPolicy | string | `"Always"` | The pull policy for the tests image. |
+| tests.image.repository | string | `"alpine/kubectl"` | An image used for testing containing sh, cat and kubectl |
+| tests.image.tag | string | `"1.36.2"` | An image tag for the tests image |
+| tests.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | The security context for the containers run as helm hook tests |
+| updater.affinity | object | `{}` |  |
+| updater.annotations | object | `{}` | Annotations to add to the updater deployment |
+| updater.enabled | bool | `true` | If true, the updater component will be deployed |
+| updater.extraArgs | object | `{}` | A key-value map of flags to pass to the updater. Since VPA 1.6.0: set "in-place-skip-disruption-budget": "true" to skip PDB checks for in-place updates when all containers have NotRequired resize policy. |
+| updater.image.pullPolicy | string | `"Always"` | The pull policy for the updater image. Recommend not changing this |
+| updater.image.repository | string | `"registry.k8s.io/autoscaling/vpa-updater"` | The location of the updater image |
+| updater.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| updater.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The liveness probe definition inside the updater pod |
+| updater.nodeSelector | object | `{}` |  |
+| updater.podAnnotations | object | `{}` | Annotations to add to the updater pod |
+| updater.podDisruptionBudget | object | `{}` | This is the setting for the pod disruption budget |
+| updater.podLabels | object | `{}` | Labels to add to the updater pod |
+| updater.podMonitor | object | `{"annotations":{},"enabled":false,"labels":{}}` | Enables a prometheus operator podMonitor for the updater |
+| updater.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | The security context for the updater pod |
+| updater.readinessProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/health-check","port":"metrics","scheme":"HTTP"},"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | The readiness probe definition inside the updater pod |
+| updater.replicaCount | int | `1` |  |
+| updater.resources | object | `{"limits":{},"requests":{"cpu":"50m","memory":"500Mi"}}` | The resources block for the updater pod |
+| updater.revisionHistoryLimit | int | `10` | The number of old replicasets to retain, default is 10, 0 will garbage-collect old replicasets |
+| updater.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The security context for the containers inside the updater pod |
+| updater.tolerations | list | `[]` |  |

--- a/stable/vpa/README.md.gotmpl
+++ b/stable/vpa/README.md.gotmpl
@@ -104,7 +104,7 @@ In the previous version, when the admissionController.cleanupOnDelete flag was s
 cleanupOnDelete:
     enabled: true
     image:
-      repository: quay.io/reactiveops/ci-images
+      repository: us-docker.pkg.dev/fairwinds-ops/oss/ci-images
       tag: v11-alpine
 
 ```


### PR DESCRIPTION
Leave CircleCI on Quay: v15-cimg-24.04 is not published to GAR yet.

**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
