### PR TITLE
[stable/insights-admission] Release version 2.0.0 of insights-admission, updating default image to GAR

### DIFF
--- a/stable/insights-admission/CHANGELOG.md
+++ b/stable/insights-admission/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.0
+* **Breaking:** Default image repository is now `us-docker.pkg.dev/fairwinds-ops/oss/insights-admission-controller` instead of Quay. AppVersion pinned to `2.3.20`.
+
 ## 1.13.0
 * Bumped admission controller image to `2.3` (insights-plugins admission `2.3.19`)
 

--- a/stable/insights-admission/Chart.yaml
+++ b/stable/insights-admission/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: insights-admission
 description: A Validating Webhook Admission Controller that utilizes Fairwinds Insights.
 type: application
-version: 1.13.0
-appVersion: "2.3"
+version: 2.0.0
+appVersion: "2.3.20"
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-admission/icon.png
 maintainers:

--- a/stable/insights-admission/README.md
+++ b/stable/insights-admission/README.md
@@ -8,6 +8,9 @@ This is an Admission Controller to reject deployment of objects into your Kubern
 
 A valid TLS certificate is required for this admission controller to work. If you have cert-manager installed then everything should work out of the box. If you don't use cert-manager and don't want to install it then you can supply a CA Bundle with the `caBundle` parameter and create a TLS secret and pass the name of that secret as `secretName`.
 
+## Changes in 2.0.0
+The default image now comes from Google Artifact Registry (`us-docker.pkg.dev/fairwinds-ops/oss/insights-admission-controller`) instead of Quay, pinned to immutable semver (`2.3.20`). If you mirror images or allow registries explicitly, update your configuration before upgrading.
+
 ```bash
 helm repo add fairwinds-stable https://charts.fairwinds.com/stable
 helm install insights-admission fairwinds-stable/insights-admission \
@@ -65,7 +68,7 @@ rules:
 | webhookConfig.mutating.enable | bool | `false` | Enable the mutating webhook, which uses settings defined in webhookConfig values. |
 | pluto.targetVersions | string | `""` | Pluto target versions specified as key=value[,key=value...]. These supersede all defaults in Pluto version files. If unset, the `k8s` component will use the current Kubernetes cluster version. For example: k8s=v1.20.0,cert-manager=v1.8.0 |
 | resources | object | `{"limits":{"cpu":1,"memory":"2Gi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | A resources block for the controller. |
-| image.repository | string | `"quay.io/fairwinds/insights-admission-controller"` | Repository for the Insights Admission Controller image |
+| image.repository | string | `"us-docker.pkg.dev/fairwinds-ops/oss/insights-admission-controller"` | Repository for the Insights Admission Controller image |
 | image.pullPolicy | string | `"Always"` | imagePullPolicy - Highly recommended to leave this as 'Always' |
 | image.tag | string | `""` | The Insights admission controller tag to use. Defaults to the Chart's AppVersion |
 | imagePullSecrets | list | `[]` | Secrets to use when pulling this image. |

--- a/stable/insights-admission/README.md.gotmpl
+++ b/stable/insights-admission/README.md.gotmpl
@@ -8,6 +8,9 @@ This is an Admission Controller to reject deployment of objects into your Kubern
 
 A valid TLS certificate is required for this admission controller to work. If you have cert-manager installed then everything should work out of the box. If you don't use cert-manager and don't want to install it then you can supply a CA Bundle with the `caBundle` parameter and create a TLS secret and pass the name of that secret as `secretName`.
 
+## Changes in 2.0.0
+The default image now comes from Google Artifact Registry (`us-docker.pkg.dev/fairwinds-ops/oss/insights-admission-controller`) instead of Quay, pinned to immutable semver (`2.3.20`). If you mirror images or allow registries explicitly, update your configuration before upgrading.
+
 ```bash
 helm repo add fairwinds-stable https://charts.fairwinds.com/stable
 helm install insights-admission fairwinds-stable/insights-admission \

--- a/stable/insights-admission/values.yaml
+++ b/stable/insights-admission/values.yaml
@@ -130,7 +130,7 @@ resources:
 
 image:
   # image.repository -- Repository for the Insights Admission Controller image
-  repository: quay.io/fairwinds/insights-admission-controller
+  repository: us-docker.pkg.dev/fairwinds-ops/oss/insights-admission-controller
   # image.pullPolicy -- imagePullPolicy - Highly recommended to leave this as 'Always'
   pullPolicy: Always
   # image.tag -- The Insights admission controller tag to use. Defaults to the Chart's AppVersion


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
