### PR TITLE
[stable/insights-agent] Update default image repositories to GAR and pin to immutable semver tags

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -122,7 +122,7 @@
       "minimumReleaseAge": "7 days"
     },
     {
-      "description": "Fairwinds-owned images skip release-age (floating X.Y tags are retagged on every patch)",
+      "description": "Fairwinds-owned images skip release-age",
       "matchManagers": ["helm-values"],
       "matchDatasources": ["docker"],
       "matchPackageNames": [

--- a/stable/insights-agent/CHANGELOG.md
+++ b/stable/insights-agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.0.0
+* **Breaking:** Default plugin images now come from Google Artifact Registry (`us-docker.pkg.dev/fairwinds-ops/oss/...`) instead of Quay. Defaults are pinned to immutable semver tags.
+* Bumped `insights-admission` chart to `2.0.*`
+
 ## 5.32.0
 * Bumped `polaris` to `v10.2.1` and switched image repository to `us-docker.pkg.dev/fairwinds-ops/oss/polaris`
 * Bumped `nova` to `v3.12.0` and switched image repository to `us-docker.pkg.dev/fairwinds-ops/oss/nova`

--- a/stable/insights-agent/Chart.lock
+++ b/stable/insights-agent/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 29.19.0
 - name: insights-admission
   repository: https://charts.fairwinds.com/stable
-  version: 1.13.0
+  version: 2.0.0
 - name: falco
   repository: https://falcosecurity.github.io/charts
   version: 9.1.0
@@ -23,5 +23,5 @@ dependencies:
 - name: device-metrics-exporter-charts
   repository: https://rocm.github.io/device-metrics-exporter
   version: v1.5.1
-digest: sha256:c91cf8f17bfaf3a4994bcff55303c1d430f892664477e06c3e6057c790012252
-generated: "2026-07-30T14:01:09.739462-03:00"
+digest: sha256:1b77e0fa401bd56c229e9cc18ad57b73288185effe220f0654a42d4b8214b741
+generated: "2026-08-04T17:03:32.170082-03:00"

--- a/stable/insights-agent/Chart.lock
+++ b/stable/insights-agent/Chart.lock
@@ -23,5 +23,5 @@ dependencies:
 - name: device-metrics-exporter-charts
   repository: https://rocm.github.io/device-metrics-exporter
   version: v1.5.1
-digest: sha256:1b77e0fa401bd56c229e9cc18ad57b73288185effe220f0654a42d4b8214b741
-generated: "2026-08-04T17:03:32.170082-03:00"
+digest: sha256:4472e33fe07d53977263a1e693113e26160306375734503f8db9db65f4cbf438
+generated: "2026-08-05T10:30:14.890894-03:00"

--- a/stable/insights-agent/Chart.yaml
+++ b/stable/insights-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to run the Fairwinds Insights agent
 name: insights-agent
-version: 5.32.0
+version: 6.0.0
 appVersion: 9.2.1
 kubeVersion: ">= 1.22.0-0"
 icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/insights-agent/icon.png
@@ -19,7 +19,7 @@ dependencies:
     condition: prometheus-metrics.installPrometheusServer
   - name: insights-admission
     repository: https://charts.fairwinds.com/stable
-    version: '1.13.*'
+    version: '2.0.*'
     condition: admission.enabled
   - name: falco
     repository: https://falcosecurity.github.io/charts

--- a/stable/insights-agent/README.md
+++ b/stable/insights-agent/README.md
@@ -5,6 +5,9 @@ to [Fairwinds Insights](https://insights.fairwinds.com).
 
 A list of breaking changes for each major version release is available at the bottom of this document.
 
+## Changes in 6.0.0
+Most plugin image defaults now come from Google Artifact Registry (`us-docker.pkg.dev/fairwinds-ops/oss/...`) instead of Quay, pinned to immutable semver tags. If you mirror images or allow registries explicitly, update your configuration before upgrading. Still on Quay: `insights-right-sizer` and `vpa-*`.
+
 ## Installation
 We recommend installing `insights-agent` in its own namespace.
 
@@ -71,9 +74,9 @@ Parameter | Description | Default
 `global.sslCertFileSecretKey` | The key, within global.sslCertFileSecretName, containing an SSL certificate file to be used when communicating with a self-hosted Insights API. | ""
 `customWorkloadAnnotations` | Additional annotations to add to each workload. (excluding Falco, uses metadata) | `{}` 
 `insights.apiToken` | Only needed if `fleetInstall=true` | ""
-`uploader.image.repository`  | The repository to pull the uploader script from | quay.io/fairwinds/insights-uploader
+`uploader.image.repository`  | The repository to pull the uploader script from | us-docker.pkg.dev/fairwinds-ops/oss/insights-uploader
 `uploader.imagePullSecret` | A pull secret for a private uploader image
-`uploader.image.tag` | The tag to use for the uploader script | 0.5
+`uploader.image.tag` | The tag to use for the uploader script | 0.6.12
 `uploader.resources` | CPU/memory requests and limits for the uploader script |
 `uploader.sendFailures` | Send logs of failure to Insights when a job fails. | true
 `uploader.env` | Set extra environment variables for the uploader script | []
@@ -153,7 +156,7 @@ Parameter | Description | Default
 `image-trust.resolveDigests` | Resolve tag-only images via registry API | `true`
 `image-trust.ignoreTlog` | Skip Rekor for keyed verification | `false`
 `image-trust.env` | Extra environment variables for the image-trust container | `{}`
-`onDemandJobRunner.image.tag` | On-demand job runner image tag; use `0.2.19` or newer for on-demand `image-trust` jobs | `0.2.19`
+`onDemandJobRunner.image.tag` | On-demand job runner image tag; use `0.2.19` or newer for on-demand `image-trust` jobs | `0.2.29`
 `opa.role` | Specifies which ClusterRole to grant the OPA agent access to | view
 `opa.additionalAccess` | Specifies additional access to grant the OPA agent. This should contain an array of objects with each having an array of apiGroups, an array of resources, and an array of verbs. Just like a RoleBinding. | null
 `insights-agent` chart twice you will want to set this flag to `false` on *one* of the installs, doesn't matter which. | true
@@ -196,8 +199,8 @@ Parameter | Description | Default
 `cloudcosts.azure.workloadIdentity.tenantId` | Azure AD Workload Identity: tenant ID (required when provider is azure) | ""
 `cloudcosts.serviceAccount.annotations` | Annotations for the cloud-costs service account, e.g. `eks.amazonaws.com/role-arn` for IRSA (AWS) | nil
 `insights-event-watcher.enabled` | Enable the insights-event-watcher component | `true`
-`insights-event-watcher.image.repository` | Repository for the insights-event-watcher image | `quay.io/fairwinds/insights-event-watcher`
-`insights-event-watcher.image.tag` | Tag for the insights-event-watcher image | `0.1`
+`insights-event-watcher.image.repository` | Repository for the insights-event-watcher image | `us-docker.pkg.dev/fairwinds-ops/oss/insights-event-watcher`
+`insights-event-watcher.image.tag` | Tag for the insights-event-watcher image | `0.2.52`
 `insights-event-watcher.logLevel` | Log level for the watcher (debug, info, warn, error) | `info`
 `insights-event-watcher.eventBufferSize` | Size of the event processing buffer | `1000`
 `insights-event-watcher.httpTimeoutSeconds` | HTTP client timeout in seconds | `30`
@@ -214,8 +217,8 @@ Parameter | Description | Default
 `insights-event-watcher.serviceAccount.annotations` | Annotations to add to the service account, e.g. `eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME` for IRSA | `nil`
 `insights-event-watcher.resources` | CPU/memory requests and limits for the watcher | See values.yaml
 `network-observability.enabled` | Enable the network observability agent DaemonSet and aggregator Deployment | `false`
-`network-observability.agent.image.repository` | Repository for the network-flow agent image | `quay.io/fairwinds/network-flow`
-`network-observability.agent.image.tag` | Tag for the network-flow agent image | `0.0`
+`network-observability.agent.image.repository` | Repository for the network-flow agent image | `us-docker.pkg.dev/fairwinds-ops/oss/network-flow`
+`network-observability.agent.image.tag` | Tag for the network-flow agent image | `0.0.14`
 `network-observability.agent.gadgetVersion` | Inspektor Gadget version used for gadgets images. When empty, uses plugins default | `""`
 `network-observability.agent.collectorAddr` | Aggregator gRPC address; defaults to the in-cluster aggregator Service | `""`
 `network-observability.agent.batchSize` | Number of flow events to batch before flushing to the aggregator; empty uses binary default (`5000`) | `""`
@@ -232,8 +235,8 @@ Parameter | Description | Default
 `network-observability.agent.priorityClassName` | Priority class for agent pods | `""` |
 `network-observability.agent.updateStrategy` | DaemonSet update strategy | `{ type: RollingUpdate }` |
 `network-observability.aggregator.replicas` | Aggregator Deployment replicas (ignored when autoscaling is enabled) | `1` |
-`network-observability.aggregator.image.repository` | Repository for the aggregator image | `quay.io/fairwinds/network-flow-aggregator` |
-`network-observability.aggregator.image.tag` | Tag for the aggregator image | `0.0` |
+`network-observability.aggregator.image.repository` | Repository for the aggregator image | `us-docker.pkg.dev/fairwinds-ops/oss/network-flow-aggregator` |
+`network-observability.aggregator.image.tag` | Tag for the aggregator image | `0.0.18` |
 `network-observability.aggregator.maxEvents` | Maximum in-memory flow events retained by the aggregator; empty uses binary default (`100000`) | `""` |
 `network-observability.aggregator.maxAge` | Maximum age of retained flow events; empty uses binary default (`15m`) | `""` |
 `network-observability.aggregator.disableKube` | Skip Kubernetes enrichment in the aggregator | `false` |

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -108,8 +108,8 @@ prometheus-metrics:
   enabled: true
   installPrometheusServer: true
   image:
-    repository: quay.io/fairwinds/prometheus-collector
-    tag: "1.0"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/prometheus-collector
+    tag: "1.9.18"
   resources:
     requests:
       cpu: 50m

--- a/stable/insights-agent/ci/test-values.yaml
+++ b/stable/insights-agent/ci/test-values.yaml
@@ -107,6 +107,9 @@ trivy:
 prometheus-metrics:
   enabled: true
   installPrometheusServer: true
+  # The e2e Prometheus has only seconds of cAdvisor history when the job runs,
+  # so the CPU rate query legitimately returns no data.
+  skipNonZeroMetricsCheck: true
   image:
     repository: us-docker.pkg.dev/fairwinds-ops/oss/prometheus-collector
     tag: "1.9.18"

--- a/stable/insights-agent/values.yaml
+++ b/stable/insights-agent/values.yaml
@@ -28,8 +28,8 @@ rbac:
 
 uploader:
   image:
-    repository: quay.io/fairwinds/insights-uploader
-    tag: "0.6"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/insights-uploader
+    tag: "0.6.12"
   imagePullSecret: ""
   sendFailures: true
   resources:
@@ -58,8 +58,8 @@ cronjobs:
 
 cronjobExecutor:
   image:
-    repository: quay.io/fairwinds/insights-utils
-    tag: "0.0"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/insights-utils
+    tag: "0.0.17"
   resources:
     requests:
       cpu: 100m
@@ -68,8 +68,8 @@ cronjobExecutor:
 installReporter:
   ttl: 300
   image:
-    repository: quay.io/fairwinds/insights-uploader
-    tag: "0.6"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/insights-uploader
+    tag: "0.6.12"
   resources:
     requests:
       cpu: 100m
@@ -160,8 +160,8 @@ opa:
   role: "view"
   timeout: 300
   image:
-    repository: quay.io/fairwinds/fw-opa
-    tag: "3.1"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/fw-opa
+    tag: "3.1.34"
   additionalAccess:
   # opa.defaultTargetResources -- A default list of Kubernetes targets to which OPA
   # policies will be applied.
@@ -211,8 +211,8 @@ workloads:
   schedule: "rand * * * *"
   timeout: 300
   image:
-    repository: quay.io/fairwinds/workloads
-    tag: "2.16"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/workloads
+    tag: "2.16.4"
   resources:
     requests:
       cpu: 100m
@@ -244,8 +244,8 @@ rbac-reporter:
   schedule: "rand * * * *"
   timeout: 300
   image:
-    repository: quay.io/fairwinds/rbac-reporter
-    tag: "1.4"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/rbac-reporter
+    tag: "1.4.26"
   resources:
     requests:
       cpu: 100m
@@ -374,8 +374,8 @@ image-trust:
   # image-trust.env -- Extra environment variables for the image-trust container.
   env: {}
   image:
-    repository: quay.io/fairwinds/image-trust
-    tag: "0.1"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/image-trust
+    tag: "0.1.9"
   resources:
     requests:
       cpu: 100m
@@ -389,12 +389,12 @@ kube-bench:
   timeout: 600
   SkipVolumes: true
   image:
-    repository: quay.io/fairwinds/fw-kube-bench
-    tag: "0.6"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/fw-kube-bench
+    tag: "0.6.26"
   aggregator:
     image:
-      repository: quay.io/fairwinds/fw-kube-bench-aggregator
-      tag: "0.4"
+      repository: us-docker.pkg.dev/fairwinds-ops/oss/fw-kube-bench-aggregator
+      tag: "0.4.23"
     resources:
       requests:
         cpu: 100m
@@ -422,8 +422,8 @@ trivy:
     TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2,docker.io/aquasec/trivy-db:2
     TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db:1,public.ecr.aws/aquasecurity/trivy-java-db:1,docker.io/aquasec/trivy-java-db:1
   image:
-    repository: quay.io/fairwinds/fw-trivy
-    tag: "0.34"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/fw-trivy
+    tag: "0.34.37"
   serviceAccount:
     annotations:
   resources:
@@ -471,8 +471,8 @@ prometheus-metrics:
   # Tenant ID for multi-tenant backends like Grafana Mimir (sets X-Scope-OrgID header)
   tenantId: ""
   image:
-    repository: quay.io/fairwinds/prometheus-collector
-    tag: "1.9"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/prometheus-collector
+    tag: "1.9.18"
   resources:
     requests:
       cpu: 100m
@@ -716,8 +716,8 @@ cloudcosts:
   schedule: "rand * * * *"
   timeout: 300
   image:
-    repository: quay.io/fairwinds/cloud-costs
-    tag: "1.1"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/cloud-costs
+    tag: "1.1.8"
   serviceAccount:
     annotations:
   resources:
@@ -821,8 +821,8 @@ right-sizer:
     timeout: 300
     # This image is for the controller, the agent only runs the Insights uploader.
     image:
-      repository: quay.io/fairwinds/right-sizer
-      tag: "0.6"
+      repository: us-docker.pkg.dev/fairwinds-ops/oss/right-sizer
+      tag: "0.6.25"
       pullPolicy: Always
 
     # oom-detection.stateconfigmapname -- The name of a ConfigMap where controller
@@ -925,8 +925,8 @@ falco:
   service:
     port: 3031
   image:
-    repository: quay.io/fairwinds/falco-agent
-    tag: "0.4"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/falco-agent
+    tag: "0.4.33"
     pullPolicy: Always
   podSecurityContext:
     fsGroup: 101
@@ -978,8 +978,8 @@ kyverno:
   enabled: false
   schedule: "rand * * * *"
   image:
-    repository: quay.io/fairwinds/kyverno
-    tag: "0.6"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/kyverno
+    tag: "0.6.9"
   resources:
     requests:
       cpu: 100m
@@ -992,8 +992,8 @@ kyverno-policy-sync:
   schedule: "0/30 * * * *"
   timeout: 600
   image:
-    repository: quay.io/fairwinds/kyverno-policy-sync
-    tag: "0.2"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/kyverno-policy-sync
+    tag: "0.2.30"
   resources:
     requests:
       cpu: 500m
@@ -1016,8 +1016,8 @@ onDemandJobRunner:
   enabled: true
   pollInterval: "15s"
   image:
-    repository: quay.io/fairwinds/on-demand-job-runner
-    tag: "0.2"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/on-demand-job-runner
+    tag: "0.2.29"
     pullPolicy: Always
   podSecurityContext:
     fsGroup: 101
@@ -1046,8 +1046,8 @@ onDemandJobRunner:
 insights-event-watcher:
   enabled: false
   image:
-    repository: quay.io/fairwinds/insights-event-watcher
-    tag: "0.2"
+    repository: us-docker.pkg.dev/fairwinds-ops/oss/insights-event-watcher
+    tag: "0.2.52"
     pullPolicy: Always
   logLevel: "info"
   # Health check configuration
@@ -1114,8 +1114,8 @@ network-observability:
   enabled: false
   agent:
     image:
-      repository: quay.io/fairwinds/network-flow
-      tag: "0.0"
+      repository: us-docker.pkg.dev/fairwinds-ops/oss/network-flow
+      tag: "0.0.14"
       pullPolicy: Always
     gadgetVersion: ""
     collectorAddr: ""
@@ -1163,8 +1163,8 @@ network-observability:
       annotations: {}
   aggregator:
     image:
-      repository: quay.io/fairwinds/network-flow-aggregator
-      tag: "0.0"
+      repository: us-docker.pkg.dev/fairwinds-ops/oss/network-flow-aggregator
+      tag: "0.0.18"
       pullPolicy: Always
     replicas: 1
     grpcPort: 4317


### PR DESCRIPTION
Also bump insights-admission chart to 2.0.0.

**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
