### PR TITLE
INS-2738: Matview refresh CronJobs to use insights_migrator

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.15.4
+* CronJobs: optional `cronjobs.<name>.useMigrationCredentials` — uses migrator Secret + `POSTGRES_OWNER_ROLE` (same as migrate Job). Enable for matview refresh jobs after owner-role migration (`action-item-filters-refresh`, `image-vulns-refresh`, `img-vulns-on-demand-refresh`).
+
 ## 9.15.3
 * Bumped `insights-api` to `18.4.6`
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.4.6"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 9.15.3
+version: 9.15.4
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -43,7 +43,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | cronjobOptions.additionalEnvVars | list | `[{"name":"POSTGRES_MAX_IDLE_CONNS","value":"1"},{"name":"POSTGRES_MAX_OPEN_CONNS","value":"1"}]` | Default additional env vars for all cronjobs (overridden per cronjob by cronjobs.<name>.additionalEnvVars) |
 | cronjobOptions.successfulJobsHistoryLimit | int | `1` | Default successful jobs history limit (overridden per cronjob by cronjobs.<name>.successfulJobsHistoryLimit) |
 | cronjobOptions.failedJobsHistoryLimit | int | `1` | Default failed jobs history limit (overridden per cronjob by cronjobs.<name>.failedJobsHistoryLimit) |
-| cronjobs.action-item-filters-refresh | object | `{"command":"action_items_filters_refresher","schedule":"0/15 * * * *"}` | Options for the action-items filters refresher job. |
+| cronjobs.action-item-filters-refresh | object | `{"command":"action_items_filters_refresher","schedule":"0/15 * * * *","useMigrationCredentials":false}` | Options for the action-items filters refresher job. useMigrationCredentials: connect as postgresql.auth.migrationUsername and set POSTGRES_OWNER_ROLE when ownerRole is configured (required to REFRESH matviews owned by insights_owner after owner-role migration). |
 | cronjobs.action-items-statistics | object | `{"command":"action_items_statistics","schedule":"15 * * * *"}` | Options for the action item stats job |
 | cronjobs.benchmark | object | `{"command":"benchmark","schedule":""}` | Options for the benchmark job |
 | cronjobs.update-tickets | object | `{"command":"update_tickets","includeGitHubSecret":true,"resources":{"limits":{"cpu":"500m","memory":"2Gi"},"requests":{"cpu":"500m","memory":"2Gi"}},"schedule":"0 * * * *"}` | Options for the update tickets job. |
@@ -55,8 +55,8 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | cronjobs.slack-channels | object | `{"command":"slack_channels_local_refresher","schedule":"0/15 * * * *"}` | Options for the slack channels job. |
 | cronjobs.trial-end | object | `{"command":"trial_end_downgrade","schedule":""}` | Options for the trial-end job. |
 | cronjobs.move-health-scores-to-ts | object | `{"command":"move_resource_health_scores_to_ts","schedule":"*/30 * * * *"}` | Options for the move-health-scores-to-ts job. |
-| cronjobs.image-vulns-refresh | object | `{"command":"image_vulnerabilities_refresher","schedule":"*/30 * * * *"}` | Options for the image-vulns-refresh job. |
-| cronjobs.img-vulns-on-demand-refresh | object | `{"command":"image_vulnerabilities_on_demand_refresher","schedule":"*/2 * * * *"}` | Options for the image-vulnerabilities-on-demand-refresher |
+| cronjobs.image-vulns-refresh | object | `{"command":"image_vulnerabilities_refresher","schedule":"*/30 * * * *","useMigrationCredentials":false}` | Options for the image-vulns-refresh job. useMigrationCredentials: same as action-item-filters-refresh (REFRESH matviews as owner). |
+| cronjobs.img-vulns-on-demand-refresh | object | `{"command":"image_vulnerabilities_on_demand_refresher","schedule":"*/2 * * * *","useMigrationCredentials":false}` | Options for the image-vulnerabilities-on-demand-refresher |
 | cronjobs.sync-action-items-iac-files | object | `{"command":"sync_action_items_iac_files","schedule":"0 * * * *"}` | Options for the sync-action-items-iac-files cronjob. |
 | cronjobs.app-groups-cves-statistics | object | `{"command":"app_groups_cves_statistics","schedule":"0 9,21 * * *"}` | Options for the app_groups_cves_statistics cronjob. |
 | cronjobs.cve-reports-email-sender | object | `{"command":"cve_reports_email_sender","schedule":"0 5 1 * *"}` | Options for the cve_reports_email_sender cronjob. |

--- a/stable/fairwinds-insights/templates/cronjobs.yaml
+++ b/stable/fairwinds-insights/templates/cronjobs.yaml
@@ -30,7 +30,7 @@ spec:
               {{- with $options.interval }}
                 - --interval={{ . }}
               {{- end }}
-              {{- include "env" (dict "useReadReplica" $options.useReadReplica "root" $) | indent 14 }}
+              {{- include "env" (dict "useReadReplica" $options.useReadReplica "useMigrationCredentials" (dig "useMigrationCredentials" false $options) "root" $) | indent 14 }}
               {{- $envVars := concat (default list $.Values.cronjobOptions.additionalEnvVars) ($options.additionalEnvVars | default list) }}
               {{- with $envVars }}
               {{- toYaml . | nindent 14 }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -105,9 +105,13 @@ cronjobOptions:
 
 cronjobs:
   # -- Options for the action-items filters refresher job.
+  # useMigrationCredentials: connect as postgresql.auth.migrationUsername and set
+  # POSTGRES_OWNER_ROLE when ownerRole is configured (required to REFRESH matviews
+  # owned by insights_owner after owner-role migration).
   action-item-filters-refresh:
     command: action_items_filters_refresher
     schedule: "0/15 * * * *"
+    useMigrationCredentials: false
 
   # -- Options for the action item stats job
   action-items-statistics:
@@ -188,14 +192,17 @@ cronjobs:
     schedule: "*/30 * * * *"
 
   # -- Options for the image-vulns-refresh job.
+  # useMigrationCredentials: same as action-item-filters-refresh (REFRESH matviews as owner).
   image-vulns-refresh:
     command: image_vulnerabilities_refresher
     schedule: "*/30 * * * *"
+    useMigrationCredentials: false
 
   # -- Options for the image-vulnerabilities-on-demand-refresher
   img-vulns-on-demand-refresh:
     command: image_vulnerabilities_on_demand_refresher
     schedule: "*/2 * * * *"
+    useMigrationCredentials: false
 
   # -- Options for the sync-action-items-iac-files cronjob.
   sync-action-items-iac-files:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
