### PR TITLE
[root] Update Kubernetes end-to-end test configurations in CircleCI to use up-to-date k8s versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,29 +154,29 @@ workflows:
       - lint-scripts
       - lint-charts
       - rok8s/kubernetes_e2e_tests:
-          name: "End-To-End Kubernetes 1.32"
-          kind_node_image: "kindest/node:v1.32.11@sha256:5fc52d52a7b9574015299724bd68f183702956aa4a2116ae75a63cb574b35af8"
-          checkout-method: full
-          executor:
-            name: ci-images-xlarge
-          <<: *kind_configuration_helm3
-      - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.33"
-          kind_node_image: "kindest/node:v1.33.7@sha256:d26ef333bdb2cbe9862a0f7c3803ecc7b4303d8cea8e814b481b09949d353040"
+          kind_node_image: "kindest/node:v1.33.12@sha256:3f5c8443c620245e4d355cfe09e96a91ead32ceaa569d3f1ca9edf0cb2fe2ff4"
           checkout-method: full
           executor:
             name: ci-images-xlarge
           <<: *kind_configuration_helm3
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.34"
-          kind_node_image: "kindest/node:v1.34.3@sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48"
+          kind_node_image: "kindest/node:v1.34.8@sha256:02722c2dedddcfc00febf5d27fbeb9b7b2c14294c82109ff4a85d89ac9ba3256"
           checkout-method: full
           executor:
             name: ci-images-xlarge
           <<: *kind_configuration_helm3
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.35"
-          kind_node_image: "kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661"
+          kind_node_image: "kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95"
+          checkout-method: full
+          executor:
+            name: ci-images-xlarge
+          <<: *kind_configuration_helm3
+      - rok8s/kubernetes_e2e_tests:
+          name: "End-To-End Kubernetes 1.36"
+          kind_node_image: "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"
           checkout-method: full
           executor:
             name: ci-images-xlarge

--- a/incubator/oom-event-generator/Chart.yaml
+++ b/incubator/oom-event-generator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: oom-event-generator
 description: A Helm chart to install kubernetes-oom-event-generator
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 1.2.0
 maintainers:
   - name: denraf

--- a/incubator/oom-event-generator/README.md
+++ b/incubator/oom-event-generator/README.md
@@ -5,7 +5,7 @@
 
 # oom-event-generator
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 A Helm chart to install kubernetes-oom-event-generator
 

--- a/incubator/oom-event-generator/README.md.gotmpl
+++ b/incubator/oom-event-generator/README.md.gotmpl
@@ -5,7 +5,7 @@
 
 # oom-event-generator
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 A Helm chart to install kubernetes-oom-event-generator
 


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
