### PR TITLE
[stable/vpa] Update VPA to 1.7.1

### DIFF
--- a/stable/vpa/Chart.yaml
+++ b/stable/vpa/Chart.yaml
@@ -2,17 +2,16 @@ apiVersion: v2
 name: vpa
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 type: application
-version: 4.12.5
-appVersion: 1.6.0
+version: 5.0.0
+appVersion: 1.7.1
 maintainers:
   - name: sudermanjr
 home: https://github.com/FairwindsOps/charts/tree/master/stable/vpa
 sources:
   - https://github.com/FairwindsOps/charts/tree/master/stable/vpa
   - https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
-# CronJobs batch/v1 were introduced in K8s 1.21
-# The VPA admission controller requests them from 0.12.0 forward
-kubeVersion: ">= 1.24.0-0"
+# VPA 1.7 supports Kubernetes 1.28 and later.
+kubeVersion: ">= 1.28.0-0"
 dependencies:
   - alias: metrics-server
     condition: metrics-server.enabled

--- a/stable/vpa/README.md
+++ b/stable/vpa/README.md
@@ -25,6 +25,22 @@ The admissionController is the only one that poses a stability consideration bec
 
 For more details, please see the values below, and the vertical pod autosclaer documentation.
 
+## *BREAKING* Upgrading to >=5.0.0
+
+VPA 1.7 requires Kubernetes 1.28 or later. The `InPlace`, `InPlaceOrRecreate`,
+and `CPUStartupBoost` features require Kubernetes 1.33 or later.
+
+Update the installed CRDs from the chart's `crds/` directory before upgrading.
+The VPA 1.7 CRDs add the `InPlace` update mode, CPU startup boost, per-VPA
+configuration fields, and observed generation status fields. Helm does not
+upgrade CRDs automatically.
+
+The `InPlace`, `CPUStartupBoost`, and `PerVPAConfig` features are alpha and
+disabled by default. Configure `InPlace` and `CPUStartupBoost` on the admission
+controller and updater. Configure `PerVPAConfig` on the admission controller,
+recommender, and updater. See the [VPA 1.7 feature documentation](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler-1.7.1/vertical-pod-autoscaler/docs/features.md)
+for configuration and requirements.
+
 ## *BREAKING* Upgrading to >=4.0.0
 
 Ensure that you update the CRDs from [the autoscaler repository](https://raw.githubusercontent.com/kubernetes/autoscaler/master/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml) or the crds/ folder.
@@ -130,8 +146,8 @@ recommender:
 
 ## Utilize In-Place Pod Vertical Scaling
 
-Since VPA 1.6.0, the `InPlaceOrRecreate` update mode is GA and enabled by default.
-No feature gate configuration is required.
+In VPA 1.7.0, the `InPlaceOrRecreate` feature gate was removed.
+No VPA feature gate configuration is required for this update mode.
 
 To use in-place scaling, configure your VPA resources with:
 

--- a/stable/vpa/README.md.gotmpl
+++ b/stable/vpa/README.md.gotmpl
@@ -25,6 +25,22 @@ The admissionController is the only one that poses a stability consideration bec
 
 For more details, please see the values below, and the vertical pod autosclaer documentation.
 
+## *BREAKING* Upgrading to >=5.0.0
+
+VPA 1.7 requires Kubernetes 1.28 or later. The `InPlace`, `InPlaceOrRecreate`,
+and `CPUStartupBoost` features require Kubernetes 1.33 or later.
+
+Update the installed CRDs from the chart's `crds/` directory before upgrading.
+The VPA 1.7 CRDs add the `InPlace` update mode, CPU startup boost, per-VPA
+configuration fields, and observed generation status fields. Helm does not
+upgrade CRDs automatically.
+
+The `InPlace`, `CPUStartupBoost`, and `PerVPAConfig` features are alpha and
+disabled by default. Configure `InPlace` and `CPUStartupBoost` on the admission
+controller and updater. Configure `PerVPAConfig` on the admission controller,
+recommender, and updater. See the [VPA 1.7 feature documentation](https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler-1.7.1/vertical-pod-autoscaler/docs/features.md)
+for configuration and requirements.
+
 ## *BREAKING* Upgrading to >=4.0.0
 
 Ensure that you update the CRDs from [the autoscaler repository](https://raw.githubusercontent.com/kubernetes/autoscaler/master/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml) or the crds/ folder.
@@ -130,8 +146,8 @@ recommender:
 
 ## Utilize In-Place Pod Vertical Scaling
 
-Since VPA 1.6.0, the `InPlaceOrRecreate` update mode is GA and enabled by default.
-No feature gate configuration is required.
+In VPA 1.7.0, the `InPlaceOrRecreate` feature gate was removed.
+No VPA feature gate configuration is required for this update mode.
 
 To use in-place scaling, configure your VPA resources with:
 

--- a/stable/vpa/crds/vpa-v1-crd.yaml
+++ b/stable/vpa/crds/vpa-v1-crd.yaml
@@ -254,6 +254,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .spec.updatePolicy.minReplicas
+      name: MinReplicas
+      priority: 1
+      type: integer
+    - jsonPath: .spec.updatePolicy.evictAfterOOMSeconds
+      name: OOMSeconds
+      priority: 1
+      type: integer
     name: v1
     schema:
       openAPIV3Schema:
@@ -354,6 +362,25 @@ spec:
                             Specifies the maximum amount of resources that will be recommended
                             for the container. The default is no maximum.
                           type: object
+                        memoryAggregationIntervalCount:
+                          description: |-
+                            memoryAggregationIntervalCount is the number of consecutive
+                            memoryAggregationIntervals which make up the memory aggregation window.
+                            The total window length is:
+                            MemoryAggregationIntervalSeconds * MemoryAggregationIntervalCount.
+                          format: int64
+                          minimum: 1
+                          type: integer
+                        memoryAggregationIntervalSeconds:
+                          description: |-
+                            memoryAggregationIntervalSeconds is the length of a single interval
+                            (in seconds) for which the peak memory usage is computed.
+                            Memory usage peaks are aggregated in multiples of this interval.
+                            In other words, there is one memory usage sample per interval
+                            (the maximum usage over that interval).
+                          format: int32
+                          minimum: 1
+                          type: integer
                         minAllowed:
                           additionalProperties:
                             anyOf:
@@ -388,8 +415,113 @@ spec:
                             when OOM is detected.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        startupBoost:
+                          description: |-
+                            startupBoost specifies the startup boost policy for the container.
+                            This overrides any pod-level startup boost policy.
+                            The startup boost policy takes precedence over the rest of the fields in
+                            this struct, except for ContainerName and ControlledValues.
+                          properties:
+                            cpu:
+                              description: |-
+                                cpu specifies the CPU startup boost policy.
+                                If this field is not set, no startup boost is applied.
+                              properties:
+                                durationSeconds:
+                                  description: |-
+                                    durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.
+                                    Defaults to 0.
+                                  format: int32
+                                  type: integer
+                                factor:
+                                  description: |-
+                                    factor specifies the factor to apply to the resource request.
+                                    This field is required when Type is "Factor".
+                                  format: int32
+                                  type: integer
+                                quantity:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    quantity specifies the absolute resource quantity to be used as the
+                                    resource request and limit during the boost phase.
+                                    This field is required when Type is "Quantity".
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: |-
+                                    type specifies the kind of boost to apply.
+                                    Supported values are: "Factor", "Quantity".
+                                    No startupboost will be applied for unrecognized values.
+                                  enum:
+                                  - Factor
+                                  - Quantity
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: factor is required when type is Factor and
+                                  forbidden otherwise
+                                rule: (self.type == 'Factor') == has(self.factor)
+                              - message: quantity is required when type is Quantity
+                                  and forbidden otherwise
+                                rule: (self.type == 'Quantity') == has(self.quantity)
+                          type: object
                       type: object
                     type: array
+                type: object
+              startupBoost:
+                description: startupBoost specifies the startup boost policy for the
+                  pod.
+                properties:
+                  cpu:
+                    description: |-
+                      cpu specifies the CPU startup boost policy.
+                      If this field is not set, no startup boost is applied.
+                    properties:
+                      durationSeconds:
+                        description: |-
+                          durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.
+                          Defaults to 0.
+                        format: int32
+                        type: integer
+                      factor:
+                        description: |-
+                          factor specifies the factor to apply to the resource request.
+                          This field is required when Type is "Factor".
+                        format: int32
+                        type: integer
+                      quantity:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          quantity specifies the absolute resource quantity to be used as the
+                          resource request and limit during the boost phase.
+                          This field is required when Type is "Quantity".
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type:
+                        description: |-
+                          type specifies the kind of boost to apply.
+                          Supported values are: "Factor", "Quantity".
+                          No startupboost will be applied for unrecognized values.
+                        enum:
+                        - Factor
+                        - Quantity
+                        type: string
+                    required:
+                    - type
+                    type: object
+                    x-kubernetes-validations:
+                    - message: factor is required when type is Factor and forbidden
+                        otherwise
+                      rule: (self.type == 'Factor') == has(self.factor)
+                    - message: quantity is required when type is Quantity and forbidden
+                        otherwise
+                      rule: (self.type == 'Quantity') == has(self.quantity)
                 type: object
               targetRef:
                 description: |-
@@ -425,6 +557,14 @@ spec:
                   If not specified, all fields in the `PodUpdatePolicy` are set to their
                   default values.
                 properties:
+                  evictAfterOOMSeconds:
+                    description: |-
+                      evictAfterOOMSeconds specifies the time in seconds to wait after an OOM event before
+                      considering the pod for eviction. Pods that have OOMed in less than this time
+                      since start will be evicted.
+                    format: int32
+                    minimum: 1
+                    type: integer
                   evictionRequirements:
                     description: |-
                       EvictionRequirements is a list of EvictionRequirements that need to
@@ -475,6 +615,7 @@ spec:
                     - Initial
                     - Recreate
                     - InPlaceOrRecreate
+                    - InPlace
                     - Auto
                     type: string
                 type: object
@@ -504,6 +645,14 @@ spec:
                         message is a human-readable explanation containing details about
                         the transition
                       type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
                     reason:
                       description: reason is the reason for the condition's last transition.
                       type: string
@@ -519,6 +668,12 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  by this autoscaler.
+                format: int64
+                minimum: 0
+                type: integer
               recommendation:
                 description: |-
                   The most recently computed amount of resources recommended by the


### PR DESCRIPTION
Fixes #1976 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Why This PR?**
VPA 1.7.1 is the latest upstream release. This updates the chart from VPA 1.6.0 and incorporates the API and compatibility changes called out in the 1.7 release notes.

**Changes**
Changes proposed in this pull request:

* Bump `appVersion` from `1.6.0` to `1.7.1` and chart version from `4.12.5` to `5.0.0`
* Refresh the bundled CRD from the `vertical-pod-autoscaler-1.7.1` tag, adding `InPlace`, CPU startup boost, per-VPA configuration, and observed generation fields
* Raise the chart's minimum Kubernetes version from 1.24 to the upstream-supported 1.28, which requires the chart major version bump
* Document the CRD upgrade requirement and alpha feature gates introduced in VPA 1.7

**Release notes reviewed**

* VPA 1.7.0: https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-1.7.0
* VPA 1.7.1: https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-1.7.1

No RBAC changes are required. The upstream deployment changes are limited to image versions and recommender labels already present in this chart.

**Testing**

* `helm lint stable/vpa --kube-version 1.28.0`
* `helm lint stable/vpa --kube-version 1.28.0 --values stable/vpa/ci/test-values.yaml`
* Rendered default, CI, and VPA 1.7 alpha feature-gate configurations
* Verified Kubernetes 1.27 is rejected by the chart constraint
* Regenerated docs with `helm-docs --sort-values-order=file` and verified a clean diff
* Verified the bundled CRD exactly matches the VPA 1.7.1 upstream artifact

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c2ca824-6b57-440c-819b-c916926e6215?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c2ca824-6b57-440c-819b-c916926e6215&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

