### PR TITLE
fix: Update VPA admission controller certgen image for multiarch support

### DIFF
--- a/stable/vpa/values.yaml
+++ b/stable/vpa/values.yaml
@@ -218,7 +218,7 @@ admissionController:
       # admissionController.certGen.image.repository -- An image that contains certgen for creating certificates. Only used if admissionController.generateCertificate is true
       repository: registry.k8s.io/ingress-nginx/kube-webhook-certgen
       # admissionController.certGen.image.tag -- An image tag for the admissionController.certGen.image.repository image. Only used if admissionController.generateCertificate is true
-      tag: v20230312-helm-chart-4.5.2-28-g66a760794
+      tag: v1.4.4
       # admissionController.certGen.image.pullPolicy -- The pull policy for the certgen image. Recommend not changing this
       pullPolicy: Always
     # admissionController.certGen.env -- Additional environment variables to be added to the certgen container. Format is KEY: Value format


### PR DESCRIPTION
## Summary
Updates the kube-webhook-certgen image tag from `v20230312-helm-chart-4.5.2-28-g66a760794` to `v1.4.4`, which includes proper multiarch support for ARM64 clusters.

## Problem
Running the VPA on an ARM64-only cluster fails when the Admission Controller is enabled due to the certGen image not supporting multiarch.

## Solution
Updated the `kube-webhook-certgen` image to the latest stable version (v1.4.4) from the ingress-nginx project, which has confirmed multiarch support.

## Testing
- Image `registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.4` is the latest stable release
- This version is actively maintained by the Kubernetes ingress-nginx community
- The image supports multiple architectures including ARM64

Fixes #854

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*