### PR TITLE
[incubator/datadog-apm] bump appversion to the latest image

### DIFF
--- a/incubator/datadog-apm/Chart.yaml
+++ b/incubator/datadog-apm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: datadog-apm
 description: A modified chart that only installs the datadog-apm agent
 type: application
-version: 2.0.0
-appVersion: "7.73.0"
+version: 2.1.0
+appVersion: "7.81.1"
 maintainers:
   - name: sudermanjr
   - name: Azahorscak

--- a/incubator/datadog-apm/README.md
+++ b/incubator/datadog-apm/README.md
@@ -5,7 +5,7 @@
 
 # datadog-apm
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.59.0](https://img.shields.io/badge/AppVersion-7.59.0-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.81.1](https://img.shields.io/badge/AppVersion-7.81.1-informational?style=flat-square)
 
 A modified chart that only installs the datadog-apm agent
 

--- a/incubator/datadog-apm/README.md.gotmpl
+++ b/incubator/datadog-apm/README.md.gotmpl
@@ -5,7 +5,7 @@
 
 # datadog-apm
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.59.0](https://img.shields.io/badge/AppVersion-7.59.0-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.81.1](https://img.shields.io/badge/AppVersion-7.81.1-informational?style=flat-square)
 
 A modified chart that only installs the datadog-apm agent
 


### PR DESCRIPTION
**Why This PR?**
Ensure that the newest datadog tag is being used by the apm

Fixes #

**Changes**
Changes proposed in this pull request:

* Bump datadog image to `7.81.1`

**Checklist:**

* [x] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
