### PR TITLE
[stable/fairwinds-insights] add exclusive admission API support

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.21.0
+* Add `admissionApi` Deployment/Service that receives admission submit traffic.
+
 ## 9.20.1
 * Add optional `gcpPricing` for Temporal `UpdateGCPCloudPricingWorkflow` on `general-worker`. Disabled by default. `enabled` sets `ENABLE_GCP_PRICING`; `projectID` and a credentials Secret are optional (ADC when no Secret).
 

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 9.21.0
 * Add `admissionApi` Deployment/Service that receives admission submit traffic.
+* When `admissionApi.ingress.enabled`, the `/v0` and `/` ingress paths become `ImplementationSpecific` star paths so the AWS LB controller keeps them below the admission rule instead of shadowing it.
 
 ## 9.20.1
 * Add optional `gcpPricing` for Temporal `UpdateGCPCloudPricingWorkflow` on `general-worker`. Disabled by default. `enabled` sets `ENABLE_GCP_PRICING`; `projectID` and a credentials Secret are optional (ADC when no Secret).

--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
 ## 9.21.0
-* Add `admissionApi` Deployment/Service that receives admission submit traffic.
-* When `admissionApi.ingress.enabled`, the `/v0` and `/` ingress paths become `ImplementationSpecific` star paths so the AWS LB controller keeps them below the admission rule instead of shadowing it.
+* Add `admissionApi` Deployment/Service that receives admission submit traffic in a separated workload.
 
 ## 9.20.1
 * Add optional `gcpPricing` for Temporal `UpdateGCPCloudPricingWorkflow` on `general-worker`. Disabled by default. `enabled` sets `ENABLE_GCP_PRICING`; `projectID` and a credentials Secret are optional (ADC when no Secret).

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.4.12"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 9.20.1
+version: 9.21.0
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -105,7 +105,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | api.hpa.min | int | `2` | Minimum number of replicas for the API server. |
 | api.hpa.max | int | `4` | Maximum number of replicas for the API server. |
 | api.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"}]` | Scaling metrics |
-| api.resources | object | `{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Resources for the API server. |
+| api.resources | object | `{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | Resources for the API server. |
 | api.nodeSelector | object | `{}` | Node Selector for the API server. |
 | api.tolerations | list | `[]` | Tolerations for the API server. |
 | api.topologySpreadConstraints[0].maxSkew | int | `1` |  |
@@ -133,7 +133,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | admissionApi.hpa.min | int | `3` | Minimum number of replicas for the admission API server. |
 | admissionApi.hpa.max | int | `6` | Maximum number of replicas for the admission API server. |
 | admissionApi.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"}]` | Scaling metrics |
-| admissionApi.resources | object | `{"limits":{"cpu":2,"memory":"4Gi"},"requests":{"cpu":2,"memory":"4Gi"}}` | Resources for the admission API server. |
+| admissionApi.resources | object | `{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | Resources for the admission API server. |
 | admissionApi.tolerations | list | `[]` | Tolerations for the admission API server. |
 | admissionApi.topologySpreadConstraints[0].maxSkew | int | `1` |  |
 | admissionApi.topologySpreadConstraints[0].topologyKey | string | `"topology.kubernetes.io/zone"` |  |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -105,7 +105,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | api.hpa.min | int | `2` | Minimum number of replicas for the API server. |
 | api.hpa.max | int | `4` | Maximum number of replicas for the API server. |
 | api.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"}]` | Scaling metrics |
-| api.resources | object | `{"limits":{"cpu":"1000m","memory":"1024Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | Resources for the API server. |
+| api.resources | object | `{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Resources for the API server. |
 | api.nodeSelector | object | `{}` | Node Selector for the API server. |
 | api.tolerations | list | `[]` | Tolerations for the API server. |
 | api.topologySpreadConstraints[0].maxSkew | int | `1` |  |
@@ -125,6 +125,31 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | api.additionalEnvVars[0].value | string | `"5"` |  |
 | api.additionalEnvVars[1].name | string | `"POSTGRES_MAX_OPEN_CONNS"` |  |
 | api.additionalEnvVars[1].value | string | `"15"` |  |
+| admissionApi.enabled | bool | `true` | Deploy a dedicated API Deployment for admission submit traffic (same insights-api image). |
+| admissionApi.replicas | int | `3` | Replica count when HPA is disabled. |
+| admissionApi.pdb.enabled | bool | `false` | Create a pod disruption budget for the admission API server. |
+| admissionApi.pdb.minReplicas | int | `1` | How many replicas should always exist for the admission API server. |
+| admissionApi.hpa.enabled | bool | `false` | Create a horizontal pod autoscaler for the admission API server. |
+| admissionApi.hpa.min | int | `3` | Minimum number of replicas for the admission API server. |
+| admissionApi.hpa.max | int | `6` | Maximum number of replicas for the admission API server. |
+| admissionApi.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"}]` | Scaling metrics |
+| admissionApi.resources | object | `{"limits":{"cpu":2,"memory":"4Gi"},"requests":{"cpu":2,"memory":"4Gi"}}` | Resources for the admission API server. |
+| admissionApi.tolerations | list | `[]` | Tolerations for the admission API server. |
+| admissionApi.topologySpreadConstraints[0].maxSkew | int | `1` |  |
+| admissionApi.topologySpreadConstraints[0].topologyKey | string | `"topology.kubernetes.io/zone"` |  |
+| admissionApi.topologySpreadConstraints[0].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
+| admissionApi.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"admission-api"` |  |
+| admissionApi.topologySpreadConstraints[0].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
+| admissionApi.topologySpreadConstraints[1].maxSkew | int | `1` |  |
+| admissionApi.topologySpreadConstraints[1].topologyKey | string | `"kubernetes.io/hostname"` |  |
+| admissionApi.topologySpreadConstraints[1].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
+| admissionApi.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"admission-api"` |  |
+| admissionApi.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
+| admissionApi.ingress.enabled | bool | `true` | Route admission submit to this service (independent of api.ingress.enabled). |
+| admissionApi.ingress.path | string | `"/v0/organizations/*/clusters/*/data/admission/submit"` | Ingress path for admission submit (ALB wildcards when pathType is ImplementationSpecific). |
+| admissionApi.ingress.pathType | string | `"ImplementationSpecific"` | Ingress path type. Use ImplementationSpecific for ALB path wildcards. |
+| admissionApi.service.type | string | `nil` | Service type for the admission API server |
+| admissionApi.additionalEnvVars | list | `[]` | Extra env vars for admission-api only (appended after shared env + api.additionalEnvVars). |
 | openApi.port | int | `8080` | Port for the Open API server to listen on. |
 | openApi.pdb.enabled | bool | `false` | Create a pod disruption budget for the Open API server. |
 | openApi.pdb.minReplicas | int | `1` | How many replicas should always exist for the Open API server. |

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -125,14 +125,14 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | api.additionalEnvVars[0].value | string | `"5"` |  |
 | api.additionalEnvVars[1].name | string | `"POSTGRES_MAX_OPEN_CONNS"` |  |
 | api.additionalEnvVars[1].value | string | `"15"` |  |
-| admissionApi.enabled | bool | `true` | Deploy a dedicated API Deployment for admission submit traffic (same insights-api image). |
+| admissionApi.enabled | bool | `false` | Deploy a dedicated API Deployment to handle admission submit traffic. |
 | admissionApi.replicas | int | `3` | Replica count when HPA is disabled. |
 | admissionApi.pdb.enabled | bool | `false` | Create a pod disruption budget for the admission API server. |
 | admissionApi.pdb.minReplicas | int | `1` | How many replicas should always exist for the admission API server. |
 | admissionApi.hpa.enabled | bool | `false` | Create a horizontal pod autoscaler for the admission API server. |
 | admissionApi.hpa.min | int | `3` | Minimum number of replicas for the admission API server. |
 | admissionApi.hpa.max | int | `6` | Maximum number of replicas for the admission API server. |
-| admissionApi.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":75,"type":"Utilization"}},"type":"Resource"}]` | Scaling metrics |
+| admissionApi.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | Scaling metrics |
 | admissionApi.resources | object | `{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | Resources for the admission API server. |
 | admissionApi.tolerations | list | `[]` | Tolerations for the admission API server. |
 | admissionApi.topologySpreadConstraints[0].maxSkew | int | `1` |  |
@@ -145,7 +145,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | admissionApi.topologySpreadConstraints[1].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
 | admissionApi.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"admission-api"` |  |
 | admissionApi.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
-| admissionApi.ingress.enabled | bool | `true` | Route admission submit to this service (independent of api.ingress.enabled). |
+| admissionApi.ingress.enabled | bool | `false` | Add the admission submit ingress path to *-admission-api. |
 | admissionApi.ingress.path | string | `"/v0/organizations/*/clusters/*/data/admission/submit"` | Ingress path for admission submit (ALB wildcards when pathType is ImplementationSpecific). |
 | admissionApi.ingress.pathType | string | `"ImplementationSpecific"` | Ingress path type. Use ImplementationSpecific for ALB path wildcards. |
 | admissionApi.service.type | string | `nil` | Service type for the admission API server |

--- a/stable/fairwinds-insights/ci/test-values.yaml
+++ b/stable/fairwinds-insights/ci/test-values.yaml
@@ -67,7 +67,6 @@ api:
     ingress:
       enabled: true
 
-
 alertsCronjob:
   schedules: []
 

--- a/stable/fairwinds-insights/ci/test-values.yaml
+++ b/stable/fairwinds-insights/ci/test-values.yaml
@@ -67,20 +67,6 @@ api:
     ingress:
       enabled: true
 
-admissionApi:
-  enabled: true
-  replicas: 1
-  pdb:
-    enabled: false
-  hpa:
-    enabled: false
-  resources:
-    limits:
-      cpu: 100m
-      memory: 128Mi
-    requests:
-      cpu: 50m
-      memory: 64Mi
 
 alertsCronjob:
   schedules: []

--- a/stable/fairwinds-insights/ci/test-values.yaml
+++ b/stable/fairwinds-insights/ci/test-values.yaml
@@ -67,6 +67,21 @@ api:
     ingress:
       enabled: true
 
+admissionApi:
+  enabled: true
+  replicas: 1
+  pdb:
+    enabled: false
+  hpa:
+    enabled: false
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
 alertsCronjob:
   schedules: []
 

--- a/stable/fairwinds-insights/templates/deployment-admission-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-admission-api.yaml
@@ -1,0 +1,114 @@
+{{- if .Values.admissionApi.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fairwinds-insights.fullname" . }}-admission-api
+  labels:
+    {{- include "fairwinds-insights.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admission-api
+    {{- if .Values.deployments.additionalLabels }}
+    {{ toYaml .Values.deployments.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if not .Values.admissionApi.hpa.enabled }}
+  replicas: {{ .Values.admissionApi.replicas }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "fairwinds-insights.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: admission-api
+  template:
+    metadata:
+      labels:
+        {{- include "fairwinds-insights.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: admission-api
+        {{- if .Values.deployments.additionalPodLabels }}
+        {{ toYaml .Values.deployments.additionalPodLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{- end }}
+      serviceAccountName: {{ include "fairwinds-insights.fullname" . }}-insights
+      containers:
+        - name: fairwinds-insights
+          image: "{{ .Values.apiImage.repository }}:{{ include "fairwinds-insights.apiImageTag" . }}"
+          imagePullPolicy: Always
+          command: ["api"]
+          args:
+          - "--port={{ .Values.api.port }}"
+          ports:
+          - name: http
+            containerPort: {{ .Values.api.port }}
+            protocol: TCP
+          {{- include "env" (dict "root" .) | indent 10 }}
+          {{- with .Values.api.additionalEnvVars }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.admissionApi.additionalEnvVars }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+            timeoutSeconds: 5
+            periodSeconds: 5
+            failureThreshold: 12
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            timeoutSeconds: 5
+            periodSeconds: 5
+            failureThreshold: 6
+          volumeMounts:
+          - name: tmp
+            mountPath: /tmp
+          - name: go-cache
+            mountPath: /.cache
+          - name: secrets
+            mountPath: /var/run/secrets/github
+          {{- if .Values.selfHostedSecret }}
+          - name: self-hosted-secret
+            mountPath: /var/run/secrets/self-hosted
+          {{- end }}
+          resources:
+            {{- toYaml .Values.admissionApi.resources | nindent 12 }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            privileged: false
+            runAsNonRoot: true
+            runAsUser: {{ .Values.api.securityContext.runAsUser }}
+            capabilities:
+              drop:
+                - ALL
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: go-cache
+        emptyDir: {}
+      - name: secrets
+        secret:
+          secretName: github-secrets
+          optional: true
+      {{- with .Values.selfHostedSecret }}
+      - name: self-hosted-secret
+        secret:
+          secretName: {{ . }}
+      {{- end }}
+    {{- with .Values.admissionApi.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.admissionApi.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/stable/fairwinds-insights/templates/ingress.yaml
+++ b/stable/fairwinds-insights/templates/ingress.yaml
@@ -1,5 +1,14 @@
 {{- if .Values.ingress.enabled }}
 {{- $fullName := include "fairwinds-insights.fullname" . -}}
+{{/*
+The admission path needs wildcards in the middle, so it can only be expressed as
+ImplementationSpecific. The AWS LB controller orders Exact, then Prefix (longest
+first), then ImplementationSpecific - so any Prefix catch-all would shadow it.
+When the admission path is routed, the catch-alls become ImplementationSpecific
+star paths too, which keeps them below it in the manifest order the controller honors.
+*/}}
+{{- $catchAllStars := or .Values.ingress.starPaths .Values.admissionApi.ingress.enabled -}}
+{{- $catchAllPathType := .Values.admissionApi.ingress.enabled | ternary "ImplementationSpecific" "Prefix" -}}
 {{- if not .Values.ingress.separate }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -50,8 +59,8 @@ spec:
                   name: http
           {{- end }}
           {{- if $.Values.api.ingress.enabled }}
-          - path: {{ $.Values.ingress.starPaths | ternary "/v0/*" "/v0" }}
-            pathType: Prefix
+          - path: {{ $catchAllStars | ternary "/v0/*" "/v0" }}
+            pathType: {{ $catchAllPathType }}
             backend:
               service:
                 name: {{ $fullName }}-api
@@ -67,8 +76,8 @@ spec:
                 port:
                   name: http
           {{- end }}
-          - path: {{ $.Values.ingress.starPaths | ternary "/*" "/" }}
-            pathType: Prefix
+          - path: {{ $catchAllStars | ternary "/*" "/" }}
+            pathType: {{ $catchAllPathType }}
             backend:
               service:
                 name: {{ $fullName }}-dashboard
@@ -119,8 +128,8 @@ spec:
                   name: http
           {{- end }}
           {{- if $.Values.api.ingress.enabled }}
-          - path: {{ $.Values.ingress.starPaths | ternary "/v0*" "/v0" }}
-            pathType: Prefix
+          - path: {{ $catchAllStars | ternary "/v0*" "/v0" }}
+            pathType: {{ $catchAllPathType }}
             backend:
               service:
                 name: {{ $fullName }}-api

--- a/stable/fairwinds-insights/templates/ingress.yaml
+++ b/stable/fairwinds-insights/templates/ingress.yaml
@@ -40,6 +40,15 @@ spec:
                 port:
                   name: http
           {{- end }}
+          {{- if $.Values.admissionApi.ingress.enabled }}
+          - path: {{ $.Values.admissionApi.ingress.path }}
+            pathType: {{ $.Values.admissionApi.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}-{{ ternary "admission-api" "api" $.Values.admissionApi.enabled }}
+                port:
+                  name: http
+          {{- end }}
           {{- if $.Values.api.ingress.enabled }}
           - path: {{ $.Values.ingress.starPaths | ternary "/v0/*" "/v0" }}
             pathType: Prefix
@@ -67,7 +76,7 @@ spec:
                   name: http
     {{- end }}
 {{- else }}
-{{- if $.Values.api.ingress.enabled }}
+{{- if or $.Values.api.ingress.enabled $.Values.admissionApi.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -100,6 +109,16 @@ spec:
     - host: {{ include "fairwinds-insights.sanitizedPrefix" $ }}{{ . }}
       http:
         paths:
+          {{- if $.Values.admissionApi.ingress.enabled }}
+          - path: {{ $.Values.admissionApi.ingress.path }}
+            pathType: {{ $.Values.admissionApi.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}-{{ ternary "admission-api" "api" $.Values.admissionApi.enabled }}
+                port:
+                  name: http
+          {{- end }}
+          {{- if $.Values.api.ingress.enabled }}
           - path: {{ $.Values.ingress.starPaths | ternary "/v0*" "/v0" }}
             pathType: Prefix
             backend:
@@ -107,6 +126,7 @@ spec:
                 name: {{ $fullName }}-api
                 port:
                   name: http
+          {{- end }}
     {{- end }}
 {{- end }}
 ---

--- a/stable/fairwinds-insights/templates/ingress.yaml
+++ b/stable/fairwinds-insights/templates/ingress.yaml
@@ -1,14 +1,9 @@
 {{- if .Values.ingress.enabled }}
 {{- $fullName := include "fairwinds-insights.fullname" . -}}
-{{/*
-The admission path needs wildcards in the middle, so it can only be expressed as
-ImplementationSpecific. The AWS LB controller orders Exact, then Prefix (longest
-first), then ImplementationSpecific - so any Prefix catch-all would shadow it.
-When the admission path is routed, the catch-alls become ImplementationSpecific
-star paths too, which keeps them below it in the manifest order the controller honors.
-*/}}
-{{- $catchAllStars := or .Values.ingress.starPaths .Values.admissionApi.ingress.enabled -}}
-{{- $catchAllPathType := .Values.admissionApi.ingress.enabled | ternary "ImplementationSpecific" "Prefix" -}}
+{{/* Admission submit path is added only when admissionApi.enabled and admissionApi.ingress.enabled. */}}
+{{- $admissionPath := and .Values.admissionApi.enabled .Values.admissionApi.ingress.enabled -}}
+{{- $catchAllStars := or .Values.ingress.starPaths $admissionPath -}}
+{{- $catchAllPathType := $admissionPath | ternary "ImplementationSpecific" "Prefix" -}}
 {{- if not .Values.ingress.separate }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -49,12 +44,12 @@ spec:
                 port:
                   name: http
           {{- end }}
-          {{- if $.Values.admissionApi.ingress.enabled }}
+          {{- if $admissionPath }}
           - path: {{ $.Values.admissionApi.ingress.path }}
             pathType: {{ $.Values.admissionApi.ingress.pathType }}
             backend:
               service:
-                name: {{ $fullName }}-{{ ternary "admission-api" "api" $.Values.admissionApi.enabled }}
+                name: {{ $fullName }}-admission-api
                 port:
                   name: http
           {{- end }}
@@ -85,7 +80,7 @@ spec:
                   name: http
     {{- end }}
 {{- else }}
-{{- if or $.Values.api.ingress.enabled $.Values.admissionApi.ingress.enabled }}
+{{- if or $.Values.api.ingress.enabled $admissionPath }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -118,12 +113,12 @@ spec:
     - host: {{ include "fairwinds-insights.sanitizedPrefix" $ }}{{ . }}
       http:
         paths:
-          {{- if $.Values.admissionApi.ingress.enabled }}
+          {{- if $admissionPath }}
           - path: {{ $.Values.admissionApi.ingress.path }}
             pathType: {{ $.Values.admissionApi.ingress.pathType }}
             backend:
               service:
-                name: {{ $fullName }}-{{ ternary "admission-api" "api" $.Values.admissionApi.enabled }}
+                name: {{ $fullName }}-admission-api
                 port:
                   name: http
           {{- end }}

--- a/stable/fairwinds-insights/templates/pdb-admission-api.yaml
+++ b/stable/fairwinds-insights/templates/pdb-admission-api.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.admissionApi.enabled .Values.admissionApi.pdb.enabled }}
+apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "fairwinds-insights.fullname" . }}-admission-api-pdb
+  labels:
+    {{- include "fairwinds-insights.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admission-api
+spec:
+  minAvailable: {{ .Values.admissionApi.pdb.minReplicas }}
+  selector:
+    matchLabels:
+      {{- include "fairwinds-insights.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: admission-api
+{{- end }}

--- a/stable/fairwinds-insights/templates/service-admission-api.yaml
+++ b/stable/fairwinds-insights/templates/service-admission-api.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.admissionApi.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fairwinds-insights.fullname" . }}-admission-api
+  labels:
+    {{- include "fairwinds-insights.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admission-api
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ default .Values.service.type .Values.admissionApi.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "fairwinds-insights.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: admission-api
+{{- end }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -391,8 +391,8 @@ api:
       value: "15"
 
 admissionApi:
-  # -- Deploy a dedicated API Deployment for admission submit traffic (same insights-api image).
-  enabled: true
+  # -- Deploy a dedicated API Deployment to handle admission submit traffic.
+  enabled: false
   # -- Replica count when HPA is disabled.
   replicas: 3
   pdb:
@@ -414,13 +414,13 @@ admissionApi:
           name: cpu
           target:
             type: Utilization
-            averageUtilization: 75
+            averageUtilization: 80
       - type: Resource
         resource:
           name: memory
           target:
             type: Utilization
-            averageUtilization: 75
+            averageUtilization: 80
   # -- Resources for the admission API server.
   resources:
     limits:
@@ -448,8 +448,8 @@ admissionApi:
           app.kubernetes.io/component: admission-api
           app.kubernetes.io/name: fairwinds-insights
   ingress:
-    # -- Route admission submit to this service (independent of api.ingress.enabled).
-    enabled: true
+    # -- Add the admission submit ingress path to *-admission-api.
+    enabled: false
     # -- Ingress path for admission submit (ALB wildcards when pathType is ImplementationSpecific).
     path: /v0/organizations/*/clusters/*/data/admission/submit
     # -- Ingress path type. Use ImplementationSpecific for ALB path wildcards.

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -350,8 +350,8 @@ api:
   # -- Resources for the API server.
   resources:
     limits:
-      cpu: 1000m
-      memory: 1024Mi
+      cpu: 500m
+      memory: 1Gi
     requests:
       cpu: 250m
       memory: 256Mi
@@ -389,6 +389,76 @@ api:
       value: "5"
     - name: POSTGRES_MAX_OPEN_CONNS
       value: "15"
+
+admissionApi:
+  # -- Deploy a dedicated API Deployment for admission submit traffic (same insights-api image).
+  enabled: true
+  # -- Replica count when HPA is disabled.
+  replicas: 3
+  pdb:
+    # -- Create a pod disruption budget for the admission API server.
+    enabled: false
+    # -- How many replicas should always exist for the admission API server.
+    minReplicas: 1
+  hpa:
+    # -- Create a horizontal pod autoscaler for the admission API server.
+    enabled: false
+    # -- Minimum number of replicas for the admission API server.
+    min: 3
+    # -- Maximum number of replicas for the admission API server.
+    max: 6
+    # -- Scaling metrics
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 75
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 75
+  # -- Resources for the admission API server.
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 250m
+      memory: 256Mi
+  # -- Tolerations for the admission API server.
+  tolerations: []
+  # topologySpreadConstraints -- Default TopologySpreadConstraints for the admission API server.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: admission-api
+          app.kubernetes.io/name: fairwinds-insights
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: admission-api
+          app.kubernetes.io/name: fairwinds-insights
+  ingress:
+    # -- Route admission submit to this service (independent of api.ingress.enabled).
+    enabled: true
+    # -- Ingress path for admission submit (ALB wildcards when pathType is ImplementationSpecific).
+    path: /v0/organizations/*/clusters/*/data/admission/submit
+    # -- Ingress path type. Use ImplementationSpecific for ALB path wildcards.
+    pathType: ImplementationSpecific
+  service:
+    # -- Service type for the admission API server
+    type:
+  # -- Extra env vars for admission-api only (appended after shared env + api.additionalEnvVars).
+  additionalEnvVars: []
 
 openApi:
   # -- Port for the Open API server to listen on.


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
