### PR TITLE
[stable/fairwinds-insights] Add HorizontalPodAutoscaler for admissionApi

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.21.3
+* Add HorizontalPodAutoscaler for `admissionApi` (`hpa-admission-api.yaml`), targeting `*-admission-api`.
+
 ## 9.21.2
 * Temporal: add `database-maintainer-worker` (`database_maintainer_worker`) for owner-only DB work (on-demand image-vulnerabilities matview refresh)
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.4.16"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 9.21.2
+version: 9.21.3
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/templates/hpa-admission-api.yaml
+++ b/stable/fairwinds-insights/templates/hpa-admission-api.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.admissionApi.enabled .Values.admissionApi.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "fairwinds-insights.fullname" . }}-admission-api-hpa
+  labels:
+    {{- include "fairwinds-insights.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: admission-api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "fairwinds-insights.fullname" . }}-admission-api
+  minReplicas: {{ .Values.admissionApi.hpa.min }}
+  maxReplicas: {{ .Values.admissionApi.hpa.max }}
+  metrics:
+  {{- toYaml .Values.admissionApi.hpa.metrics | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
