### PR TITLE
[stable/fairwinds-insights] admissionApi no longer inherits port, additionalEnvVars, or securityContext from api

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.22.1
+* `admissionApi` no longer inherits `api.port`, `api.additionalEnvVars`, or `api.securityContext`. Configure those under `admissionApi` instead.
+
 ## 9.22.0
 * Bumped `agentChartTarget` to `6.2.0`
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.4.18"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 9.22.0
+version: 9.22.1
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -126,6 +126,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | api.additionalEnvVars[1].name | string | `"POSTGRES_MAX_OPEN_CONNS"` |  |
 | api.additionalEnvVars[1].value | string | `"15"` |  |
 | admissionApi.enabled | bool | `false` | Deploy a dedicated API Deployment to handle admission submit traffic. |
+| admissionApi.port | int | `8080` | Port for the admission API server to listen on. |
 | admissionApi.replicas | int | `3` | Replica count when HPA is disabled. |
 | admissionApi.pdb.enabled | bool | `false` | Create a pod disruption budget for the admission API server. |
 | admissionApi.pdb.minReplicas | int | `1` | How many replicas should always exist for the admission API server. |
@@ -145,11 +146,12 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | admissionApi.topologySpreadConstraints[1].whenUnsatisfiable | string | `"ScheduleAnyway"` |  |
 | admissionApi.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/component" | string | `"admission-api"` |  |
 | admissionApi.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
+| admissionApi.securityContext.runAsUser | int | `10324` | The user ID to run the admission API server under. |
 | admissionApi.ingress.enabled | bool | `false` | Add the admission submit ingress path to *-admission-api. |
 | admissionApi.ingress.path | string | `"/v0/organizations/*/clusters/*/data/admission/submit"` | Ingress path for admission submit (ALB wildcards when pathType is ImplementationSpecific). |
 | admissionApi.ingress.pathType | string | `"ImplementationSpecific"` | Ingress path type. Use ImplementationSpecific for ALB path wildcards. |
 | admissionApi.service.type | string | `nil` | Service type for the admission API server |
-| admissionApi.additionalEnvVars | list | `[]` | Extra env vars for admission-api only (appended after shared env + api.additionalEnvVars). |
+| admissionApi.additionalEnvVars | list | `[{"name":"POSTGRES_MAX_IDLE_CONNS","value":"5"},{"name":"POSTGRES_MAX_OPEN_CONNS","value":"15"}]` | Extra env vars for the admission API server. |
 | openApi.port | int | `8080` | Port for the Open API server to listen on. |
 | openApi.pdb.enabled | bool | `false` | Create a pod disruption budget for the Open API server. |
 | openApi.pdb.minReplicas | int | `1` | How many replicas should always exist for the Open API server. |

--- a/stable/fairwinds-insights/templates/deployment-admission-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-admission-api.yaml
@@ -37,15 +37,12 @@ spec:
           imagePullPolicy: Always
           command: ["api"]
           args:
-          - "--port={{ .Values.api.port }}"
+          - "--port={{ .Values.admissionApi.port }}"
           ports:
           - name: http
-            containerPort: {{ .Values.api.port }}
+            containerPort: {{ .Values.admissionApi.port }}
             protocol: TCP
           {{- include "env" (dict "root" .) | indent 10 }}
-          {{- with .Values.api.additionalEnvVars }}
-            {{- toYaml . | nindent 10 }}
-          {{- end }}
           {{- with .Values.admissionApi.additionalEnvVars }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -81,7 +78,7 @@ spec:
             allowPrivilegeEscalation: false
             privileged: false
             runAsNonRoot: true
-            runAsUser: {{ .Values.api.securityContext.runAsUser }}
+            runAsUser: {{ .Values.admissionApi.securityContext.runAsUser }}
             capabilities:
               drop:
                 - ALL

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -393,6 +393,8 @@ api:
 admissionApi:
   # -- Deploy a dedicated API Deployment to handle admission submit traffic.
   enabled: false
+  # -- Port for the admission API server to listen on.
+  port: 8080
   # -- Replica count when HPA is disabled.
   replicas: 3
   pdb:
@@ -447,6 +449,9 @@ admissionApi:
         matchLabels:
           app.kubernetes.io/component: admission-api
           app.kubernetes.io/name: fairwinds-insights
+  securityContext:
+    # -- The user ID to run the admission API server under.
+    runAsUser: 10324
   ingress:
     # -- Add the admission submit ingress path to *-admission-api.
     enabled: false
@@ -457,8 +462,12 @@ admissionApi:
   service:
     # -- Service type for the admission API server
     type:
-  # -- Extra env vars for admission-api only (appended after shared env + api.additionalEnvVars).
-  additionalEnvVars: []
+  # -- Extra env vars for the admission API server.
+  additionalEnvVars:
+    - name: POSTGRES_MAX_IDLE_CONNS
+      value: "5"
+    - name: POSTGRES_MAX_OPEN_CONNS
+      value: "15"
 
 openApi:
   # -- Port for the Open API server to listen on.


### PR DESCRIPTION
Fix internal INS-2795

**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
