### PR TITLE
[stable/fairwinds-insights] Add support for options.externalSecret to provision fwinsights-secrets via ESO

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 10.0.2
+* Add optional `options.externalSecret` to provision `fwinsights-secrets` (or `options.secretName`) via External Secrets Operator. Invalid together with `options.autogenerateKeys`.
+
 ## 10.0.1
 * Bumped `insights-api` to `18.4.22`
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.4.22"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 10.0.1
+version: 10.0.2
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -31,9 +31,15 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | options.dashboardConfig | string | `"config.self.js"` | Configuration file to use for the front-end. This generally should not be changed. |
 | options.adminEmail | string | `nil` | An email address for the first admin user. This account will get created automatically but without a known password. You must initiate a password reset in order to login to this account. |
 | options.organizationName | string | `nil` | The name of your organization. This will pre-populate Insights with an organization. |
-| options.autogenerateKeys | bool | `false` | Autogenerate keys for session tracking. For testing/demo purposes only |
+| options.autogenerateKeys | bool | `false` | Autogenerate keys for session tracking. For testing/demo purposes only. Invalid together with `externalSecret.create`. |
 | options.migrateHealthScore | bool | `false` | Run the job to migrate health scores to a new format |
-| options.secretName | string | `"fwinsights-secrets"` | Name of the secret where session keys and other secrets are stored |
+| options.secretName | string | `"fwinsights-secrets"` | Name of the secret where session keys and other secrets are stored. Also the Secret ESO creates when `externalSecret.create` is true. |
+| options.externalSecret | object | `{"annotations":{},"create":false,"data":[],"name":"","refreshInterval":"1h","secretStoreRef":{"kind":"ClusterSecretStore","name":"fairwinds-vault-backend"}}` | ExternalSecret for `secretName`. Cannot be combined with `autogenerateKeys`. |
+| options.externalSecret.create | bool | `false` | When true, create an ExternalSecret that syncs into `secretName`. Invalid together with `autogenerateKeys`. |
+| options.externalSecret.name | string | `""` | Optional ExternalSecret CR name. Empty: same as `secretName`. |
+| options.externalSecret.secretStoreRef | object | `{"kind":"ClusterSecretStore","name":"fairwinds-vault-backend"}` | SecretStore reference |
+| options.externalSecret.annotations | object | `{}` | Extra annotations on the ExternalSecret resource (e.g. argocd.argoproj.io/sync-wave) |
+| options.externalSecret.data | list | `[]` | ExternalSecret spec.data entries (required when create is true). Each needs `secretKey` and `remoteRef.key` (`property` optional). |
 | options.overprovisioning.enabled | bool | `false` |  |
 | options.overprovisioning.cpu | string | `"1000m"` |  |
 | options.overprovisioning.memory | string | `"1Gi"` |  |

--- a/stable/fairwinds-insights/templates/_helpers.tpl
+++ b/stable/fairwinds-insights/templates/_helpers.tpl
@@ -365,7 +365,24 @@ true
 {{- end -}}
 {{- end -}}
 
+{{- define "fairwinds-insights.validateAppSecrets" -}}
+{{- $ext := .Values.options.externalSecret | default dict -}}
+{{- if and .Values.options.autogenerateKeys $ext.create -}}
+{{- fail "options.autogenerateKeys and options.externalSecret.create cannot both be set; pick Chart-managed (autogenerateKeys: true, create: false) or External (autogenerateKeys: false, create: true)" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fairwinds-insights.appExternalSecretName" -}}
+{{- $ext := .Values.options.externalSecret | default dict -}}
+{{- if $ext.name -}}
+{{- $ext.name -}}
+{{- else -}}
+{{- .Values.options.secretName -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "fairwinds-insights.validateDatabaseSecrets" -}}
+{{- include "fairwinds-insights.validateAppSecrets" . -}}
 {{- include "fairwinds-insights.validatePostgresqlAuth" . -}}
 {{- include "fairwinds-insights.validateTimescaleAuth" . -}}
 {{- end -}}

--- a/stable/fairwinds-insights/templates/secrets.externalsecret.yaml
+++ b/stable/fairwinds-insights/templates/secrets.externalsecret.yaml
@@ -1,0 +1,44 @@
+{{- $externalSecret := .Values.options.externalSecret | default dict }}
+{{- if $externalSecret.create }}
+{{- include "fairwinds-insights.validateAppSecrets" . }}
+{{- if not $externalSecret.data }}
+{{- fail "options.externalSecret.create is true but options.externalSecret.data is empty; provide at least one entry with secretKey and remoteRef.key (property optional)." }}
+{{- end }}
+{{- range $i, $entry := $externalSecret.data }}
+{{- if not $entry.secretKey }}
+{{- fail (printf "options.externalSecret.data[%d] is missing required field 'secretKey'" $i) }}
+{{- end }}
+{{- if not $entry.remoteRef }}
+{{- fail (printf "options.externalSecret.data[%d] is missing required field 'remoteRef'" $i) }}
+{{- end }}
+{{- if not $entry.remoteRef.key }}
+{{- fail (printf "options.externalSecret.data[%d].remoteRef is missing required field 'key'" $i) }}
+{{- end }}
+{{- end }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "fairwinds-insights.appExternalSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fairwinds-insights.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-10"
+  {{- with $externalSecret.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: {{ $externalSecret.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ $externalSecret.secretStoreRef.name }}
+    kind: {{ $externalSecret.secretStoreRef.kind }}
+  target:
+    name: {{ .Values.options.secretName }}
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    {{- toYaml $externalSecret.data | nindent 4 }}
+{{- end }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -56,12 +56,49 @@ options:
   adminEmail:
   # -- The name of your organization. This will pre-populate Insights with an organization.
   organizationName:
-  # -- Autogenerate keys for session tracking. For testing/demo purposes only
+  # -- Autogenerate keys for session tracking. For testing/demo purposes only. Invalid together with `externalSecret.create`.
   autogenerateKeys: false
   # -- Run the job to migrate health scores to a new format
   migrateHealthScore: false
-  # -- Name of the secret where session keys and other secrets are stored
+  # -- Name of the secret where session keys and other secrets are stored. Also the Secret ESO creates when `externalSecret.create` is true.
   secretName: fwinsights-secrets
+  # -- ExternalSecret for `secretName`. Cannot be combined with `autogenerateKeys`.
+  externalSecret:
+    # -- When true, create an ExternalSecret that syncs into `secretName`. Invalid together with `autogenerateKeys`.
+    create: false
+    # -- Optional ExternalSecret CR name. Empty: same as `secretName`.
+    name: ""
+    refreshInterval: 1h
+    # -- SecretStore reference
+    secretStoreRef:
+      name: fairwinds-vault-backend
+      kind: ClusterSecretStore
+    # -- Extra annotations on the ExternalSecret resource (e.g. argocd.argoproj.io/sync-wave)
+    annotations: {}
+    # -- ExternalSecret spec.data entries (required when create is true). Each needs `secretKey` and `remoteRef.key` (`property` optional).
+    data: []
+    # Example:
+    # - secretKey: COOKIE_HASH_KEY
+    #   remoteRef:
+    #     key: your/vault/path
+    #     property: COOKIE_HASH_KEY
+    # - secretKey: COOKIE_BLOCK_KEY
+    #   remoteRef:
+    #     key: your/vault/path
+    #     property: COOKIE_BLOCK_KEY
+    # - secretKey: SESSION_AUTH_KEY
+    #   remoteRef:
+    #     key: your/vault/path
+    #     property: SESSION_AUTH_KEY
+    # - secretKey: SESSION_ENCRYPTION_KEY
+    #   remoteRef:
+    #     key: your/vault/path
+    #     property: SESSION_ENCRYPTION_KEY
+    # - secretKey: AES_BASE64_CYPHER_KEY
+    #   remoteRef:
+    #     key: your/vault/path
+    #     property: AES_BASE64_CYPHER_KEY
+
 
   # This adds an empty low-priority pod, so we don't have
   # to wait for cluster-autoscaler with each deployment


### PR DESCRIPTION


**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
