### PR TITLE
[root] Remove major update grouping configurations in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -80,29 +80,14 @@
       "enabled": false
     },
     {
-      "matchManagers": ["helmv3"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "Helm chart major updates"
-    },
-    {
       "matchManagers": ["helm-values"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "Helm values non-major updates"
     },
     {
-      "matchManagers": ["helm-values"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "Helm values major updates"
-    },
-    {
       "matchManagers": ["circleci"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "CircleCI non-major updates"
-    },
-    {
-      "matchManagers": ["circleci"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "CircleCI major updates"
     },
     {
       "description": "Bump chart version on dependency and image updates",


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
