### PR TITLE
[circleci] Use resource type large.gen2 for k8s e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,8 @@ executors:
   ci-images:
     docker:
       - image: quay.io/reactiveops/ci-images:v15-cimg-24.04
-  ci-images-xlarge:
-    resource_class: xlarge
+  ci-images-medium-plus-gen2:
+    resource_class: medium+.gen2
     docker:
       - image: quay.io/reactiveops/ci-images:v15-cimg-24.04
 
@@ -176,28 +176,28 @@ workflows:
           kind_node_image: "kindest/node:v1.33.12@sha256:3f5c8443c620245e4d355cfe09e96a91ead32ceaa569d3f1ca9edf0cb2fe2ff4"
           checkout-method: full
           executor:
-            name: ci-images-xlarge
+            name: ci-images-medium-plus-gen2
           <<: *kind_configuration_helm3
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.34"
           kind_node_image: "kindest/node:v1.34.8@sha256:02722c2dedddcfc00febf5d27fbeb9b7b2c14294c82109ff4a85d89ac9ba3256"
           checkout-method: full
           executor:
-            name: ci-images-xlarge
+            name: ci-images-medium-plus-gen2
           <<: *kind_configuration_helm3
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.35"
           kind_node_image: "kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95"
           checkout-method: full
           executor:
-            name: ci-images-xlarge
+            name: ci-images-medium-plus-gen2
           <<: *kind_configuration_helm3
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.36"
           kind_node_image: "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"
           checkout-method: full
           executor:
-            name: ci-images-xlarge
+            name: ci-images-medium-plus-gen2
           <<: *kind_configuration_helm3
       - sync:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,8 @@ executors:
   ci-images:
     docker:
       - image: quay.io/reactiveops/ci-images:v15-cimg-24.04
-  ci-images-medium-plus-gen2:
-    resource_class: medium+.gen2
+  ci-images-large-gen2:
+    resource_class: large.gen2
     docker:
       - image: quay.io/reactiveops/ci-images:v15-cimg-24.04
 
@@ -176,28 +176,28 @@ workflows:
           kind_node_image: "kindest/node:v1.33.12@sha256:3f5c8443c620245e4d355cfe09e96a91ead32ceaa569d3f1ca9edf0cb2fe2ff4"
           checkout-method: full
           executor:
-            name: ci-images-medium-plus-gen2
+            name: ci-images-large-gen2
           <<: *kind_configuration_helm3
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.34"
           kind_node_image: "kindest/node:v1.34.8@sha256:02722c2dedddcfc00febf5d27fbeb9b7b2c14294c82109ff4a85d89ac9ba3256"
           checkout-method: full
           executor:
-            name: ci-images-medium-plus-gen2
+            name: ci-images-large-gen2
           <<: *kind_configuration_helm3
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.35"
           kind_node_image: "kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95"
           checkout-method: full
           executor:
-            name: ci-images-medium-plus-gen2
+            name: ci-images-large-gen2
           <<: *kind_configuration_helm3
       - rok8s/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.36"
           kind_node_image: "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"
           checkout-method: full
           executor:
-            name: ci-images-medium-plus-gen2
+            name: ci-images-large-gen2
           <<: *kind_configuration_helm3
       - sync:
           requires:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
