### PR TITLE
[stable/fairwinds-insights] Add support for configurable GitHub secrets in resources

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 10.1.2
+* CronJobs mount the GitHub secret when either `cronjobs.<name>.includeGitHubSecret` or `cronjobs.<name>.githubSecret.enabled` is set.
+* Configurable GitHub secret name (default `github-secrets`) via `cronjobs.<name>.githubSecret.name`, `api.githubSecret.name`, `admissionApi.githubSecret.name`, and `reportjob.githubSecret.name`. Temporal workers already allow this through `volumes`.
+
 ## 10.1.1
 * Bumped `insights-api` to `18.4.24`
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.4.24"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 10.1.1
+version: 10.1.2
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -97,6 +97,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | dashboard.topologySpreadConstraints[1].labelSelector.matchLabels."app.kubernetes.io/name" | string | `"fairwinds-insights"` |  |
 | dashboard.securityContext.runAsUser | int | `101` | The user ID to run the Dashboard under. comes from https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/stable/alpine/Dockerfile |
 | api.port | int | `8080` | Port for the API server to listen on. |
+| api.githubSecret.name | string | `"github-secrets"` | Secret mounted at /var/run/secrets/github on the API pods (optional Secret). |
 | api.grpc.enabled | bool | `false` | Enable network-flow gRPC server configuration. |
 | api.grpc.address | string | `""` | Listen address for the network-flow gRPC server (INSIGHTS_GRPC_ADDR). Defaults to :4318 when enabled and empty. |
 | api.grpc.port | int | `4318` | Container and Service port for the network-flow gRPC server. |
@@ -134,6 +135,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | admissionApi.enabled | bool | `false` | Deploy a dedicated API Deployment to handle admission submit traffic. |
 | admissionApi.port | int | `8080` | Port for the admission API server to listen on. |
 | admissionApi.replicas | int | `3` | Replica count when HPA is disabled. |
+| admissionApi.githubSecret.name | string | `"github-secrets"` | Secret mounted at /var/run/secrets/github on the admission API pods (optional Secret). |
 | admissionApi.pdb.enabled | bool | `false` | Create a pod disruption budget for the admission API server. |
 | admissionApi.pdb.minReplicas | int | `1` | How many replicas should always exist for the admission API server. |
 | admissionApi.hpa.enabled | bool | `false` | Create a horizontal pod autoscaler for the admission API server. |
@@ -366,6 +368,7 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | cronjobExecutor.resources.requests.cpu | string | `"1m"` |  |
 | cronjobExecutor.resources.requests.memory | string | `"3Mi"` |  |
 | reportjob.enabled | bool | `true` |  |
+| reportjob.githubSecret.name | string | `"github-secrets"` | Secret mounted at /var/run/secrets/github on the report job pods (optional Secret). |
 | reportjob.pdb.enabled | bool | `true` |  |
 | reportjob.pdb.minReplicas | int | `1` |  |
 | reportjob.hpa.enabled | bool | `true` |  |

--- a/stable/fairwinds-insights/templates/cronjobs.yaml
+++ b/stable/fairwinds-insights/templates/cronjobs.yaml
@@ -38,18 +38,21 @@ spec:
               imagePullPolicy: Always
               resources:
                 {{- toYaml (default $.Values.cronjobOptions.resources $options.resources) | nindent 16 }}
-              {{- if $options.includeGitHubSecret }}
+              {{- $githubSecret := $options.githubSecret | default dict }}
+              {{- $githubSecretEnabled := or $options.includeGitHubSecret ($githubSecret.enabled | default false) }}
+              {{- $githubSecretName := $githubSecret.name | default "github-secrets" }}
+              {{- if $githubSecretEnabled }}
               volumeMounts:
               - name: secrets
                 mountPath: /var/run/secrets/github
               {{- end }}
               securityContext:
                 {{- toYaml (default $.Values.cronjobOptions.securityContext $options.securityContext) | nindent 16 }}
-          {{- if $options.includeGitHubSecret }}
+          {{- if $githubSecretEnabled }}
           volumes:
             - name: secrets
               secret:
-                secretName: github-secrets
+                secretName: {{ $githubSecretName }}
                 optional: true
           {{- end }}
 ---

--- a/stable/fairwinds-insights/templates/deployment-admission-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-admission-api.yaml
@@ -93,7 +93,7 @@ spec:
         emptyDir: {}
       - name: secrets
         secret:
-          secretName: github-secrets
+          secretName: {{ .Values.admissionApi.githubSecret.name | default "github-secrets" }}
           optional: true
       {{- with .Values.selfHostedSecret }}
       - name: self-hosted-secret

--- a/stable/fairwinds-insights/templates/deployment-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-api.yaml
@@ -102,7 +102,7 @@ spec:
         emptyDir: {}
       - name: secrets
         secret:
-          secretName: github-secrets
+          secretName: {{ .Values.api.githubSecret.name | default "github-secrets" }}
           optional: true
       {{- with .Values.selfHostedSecret }}
       - name: self-hosted-secret

--- a/stable/fairwinds-insights/templates/deployment-report-job.yaml
+++ b/stable/fairwinds-insights/templates/deployment-report-job.yaml
@@ -65,7 +65,7 @@ spec:
       volumes:
         - name: secrets
           secret:
-            secretName: github-secrets
+            secretName: {{ .Values.reportjob.githubSecret.name | default "github-secrets" }}
             optional: true
     {{- with .Values.reportjob.tolerations }}
       tolerations:

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -339,6 +339,9 @@ dashboard:
 api:
   # -- Port for the API server to listen on.
   port: 8080
+  githubSecret:
+    # -- Secret mounted at /var/run/secrets/github on the API pods (optional Secret).
+    name: github-secrets
   grpc:
     # -- Enable network-flow gRPC server configuration.
     enabled: false
@@ -434,6 +437,9 @@ admissionApi:
   port: 8080
   # -- Replica count when HPA is disabled.
   replicas: 3
+  githubSecret:
+    # -- Secret mounted at /var/run/secrets/github on the admission API pods (optional Secret).
+    name: github-secrets
   pdb:
     # -- Create a pod disruption budget for the admission API server.
     enabled: false
@@ -1152,6 +1158,9 @@ cronjobExecutor:
 
 reportjob:
   enabled: true
+  githubSecret:
+    # -- Secret mounted at /var/run/secrets/github on the report job pods (optional Secret).
+    name: github-secrets
   pdb:
     enabled: true
     minReplicas: 1


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
