### PR TITLE
[stable/fairwinds-insights] Add githubSecret.externalSecret support for GitHub integration via ESO

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 10.1.3
+* Add optional `githubSecret.externalSecret` to provision the GitHub integration Secret (default `github-secrets`) via External Secrets Operator.
+
 ## 10.1.2
 * CronJobs mount the GitHub secret when either `cronjobs.<name>.includeGitHubSecret` or `cronjobs.<name>.githubSecret.enabled` is set.
 * Configurable GitHub secret name (default `github-secrets`) via `cronjobs.<name>.githubSecret.name`, `api.githubSecret.name`, `admissionApi.githubSecret.name`, and `reportjob.githubSecret.name`. Temporal workers already allow this through `volumes`.

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.4.24"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 10.1.2
+version: 10.1.3
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -44,6 +44,12 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | options.overprovisioning.cpu | string | `"1000m"` |  |
 | options.overprovisioning.memory | string | `"1Gi"` |  |
 | options.ssoRequiredForAdminAPI | bool | `false` | Whether to require SSO for the admin API |
+| githubSecret | object | `{"externalSecret":{"annotations":{},"create":false,"data":[],"name":"github-secrets","refreshInterval":"1h","secretStoreRef":{"kind":"ClusterSecretStore","name":"fairwinds-vault-backend"}}}` | GitHub integration Secret. Workloads mount it at /var/run/secrets/github (optional). Set externalSecret.create to provision it via External Secrets Operator. |
+| githubSecret.externalSecret.create | bool | `false` | When true, create an ExternalSecret that syncs into this Secret. |
+| githubSecret.externalSecret.name | string | `"github-secrets"` | ExternalSecret CR name and the Secret it creates (default github-secrets). Must match api/admissionApi/reportjob/cronjobs.githubSecret.name and temporalDeploymentDefaults.volumes when customized. |
+| githubSecret.externalSecret.secretStoreRef | object | `{"kind":"ClusterSecretStore","name":"fairwinds-vault-backend"}` | SecretStore reference |
+| githubSecret.externalSecret.annotations | object | `{}` | Extra annotations on the ExternalSecret resource (e.g. argocd.argoproj.io/sync-wave) |
+| githubSecret.externalSecret.data | list | `[]` | ExternalSecret spec.data entries (required when create is true). Each needs `secretKey` and `remoteRef.key` (`property` optional). |
 | cronjobOptions.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":10324}` | Default security context for cronjobs |
 | cronjobOptions.resources | object | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Default resources for cronjobs |
 | cronjobOptions.additionalEnvVars | list | `[{"name":"POSTGRES_MAX_IDLE_CONNS","value":"1"},{"name":"POSTGRES_MAX_OPEN_CONNS","value":"1"}]` | Default additional env vars for all cronjobs (overridden per cronjob by cronjobs.<name>.additionalEnvVars) |

--- a/stable/fairwinds-insights/templates/_helpers.tpl
+++ b/stable/fairwinds-insights/templates/_helpers.tpl
@@ -518,6 +518,12 @@ https://insights.fairwinds.com
 {{- if (dig "keda" "enabled" $default $options) -}}true{{- else -}}false{{- end -}}
 {{- end -}}
 
+{{- define "fairwinds-insights.githubSecretName" -}}
+{{- $p := .Values.githubSecret | default dict -}}
+{{- $ext := $p.externalSecret | default dict -}}
+{{- $ext.name | default "github-secrets" -}}
+{{- end -}}
+
 {{/*
 Secret name for GCP pricing credentials.
 ESO path: externalSecret.name (default gcp-pricing-credentials-external).

--- a/stable/fairwinds-insights/templates/github.externalsecret.yaml
+++ b/stable/fairwinds-insights/templates/github.externalsecret.yaml
@@ -1,0 +1,45 @@
+{{- $gh := .Values.githubSecret | default dict }}
+{{- $externalSecret := $gh.externalSecret | default dict }}
+{{- if $externalSecret.create }}
+{{- if not $externalSecret.data }}
+{{- fail "githubSecret.externalSecret.create is true but githubSecret.externalSecret.data is empty; provide at least one entry with secretKey and remoteRef.key (property optional)." }}
+{{- end }}
+{{- range $i, $entry := $externalSecret.data }}
+{{- if not $entry.secretKey }}
+{{- fail (printf "githubSecret.externalSecret.data[%d] is missing required field 'secretKey'" $i) }}
+{{- end }}
+{{- if not $entry.remoteRef }}
+{{- fail (printf "githubSecret.externalSecret.data[%d] is missing required field 'remoteRef'" $i) }}
+{{- end }}
+{{- if not $entry.remoteRef.key }}
+{{- fail (printf "githubSecret.externalSecret.data[%d].remoteRef is missing required field 'key'" $i) }}
+{{- end }}
+{{- end }}
+{{- $secretName := include "fairwinds-insights.githubSecretName" . | trim }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fairwinds-insights.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-10"
+  {{- with $externalSecret.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: {{ $externalSecret.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ $externalSecret.secretStoreRef.name }}
+    kind: {{ $externalSecret.secretStoreRef.kind }}
+  target:
+    name: {{ $secretName }}
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    {{- toYaml $externalSecret.data | nindent 4 }}
+{{- end }}

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -110,6 +110,29 @@ options:
   # -- Whether to require SSO for the admin API
   ssoRequiredForAdminAPI: false
 
+# -- GitHub integration Secret. Workloads mount it at /var/run/secrets/github (optional). Set externalSecret.create to provision it via External Secrets Operator.
+githubSecret:
+  externalSecret:
+    # -- When true, create an ExternalSecret that syncs into this Secret.
+    create: false
+    # -- ExternalSecret CR name and the Secret it creates (default github-secrets). Must match api/admissionApi/reportjob/cronjobs.githubSecret.name and temporalDeploymentDefaults.volumes when customized.
+    name: github-secrets
+    refreshInterval: 1h
+    # -- SecretStore reference
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: fairwinds-vault-backend
+    # -- Extra annotations on the ExternalSecret resource (e.g. argocd.argoproj.io/sync-wave)
+    annotations: {}
+    # -- ExternalSecret spec.data entries (required when create is true). Each needs `secretKey` and `remoteRef.key` (`property` optional).
+    data: []
+    # Example:
+    # data:
+    #   - secretKey: github.pem
+    #     remoteRef:
+    #       key: my-infrastructure/my-cluster/insights/github
+    #       property: github.pem
+
 cronjobOptions:
   # -- Default security context for cronjobs
   securityContext:


### PR DESCRIPTION

**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
