### PR TITLE
[stable/fairwinds-insights] Add support for optional selfHostedSecret and image externalSecret to provision Secrets via ESO

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 10.1.4
+* Add optional `selfHostedSecret.externalSecret` (default Secret `self-hosted-key`) and `image.externalSecret` (default Secret `pull-secret`) to provision those Secrets via External Secrets Operator. A string `selfHostedSecret` / `image.pullSecret` still names an existing Secret.
+
 ## 10.1.3
 * Add optional `githubSecret.externalSecret` to provision the GitHub integration Secret (default `github-secrets`) via External Secrets Operator.
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.4.24"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 10.1.3
+version: 10.1.4
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -11,6 +11,13 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image.tag | string | `nil` | Docker image tag, defaults to the Chart appVersion |
+| image.pullSecret | string | `nil` | Existing dockerconfigjson Secret name for imagePullSecrets. Empty: none unless `externalSecret.create`. Invalid together with `externalSecret.create`. |
+| image.externalSecret | object | `{"annotations":{},"create":false,"data":[],"name":"pull-secret","refreshInterval":"1h","secretStoreRef":{"kind":"ClusterSecretStore","name":"fairwinds-vault-backend"}}` | ExternalSecret for the image pull Secret. Cannot be combined with `pullSecret`. |
+| image.externalSecret.create | bool | `false` | When true, create an ExternalSecret (type kubernetes.io/dockerconfigjson) and set imagePullSecrets on Insights workloads. |
+| image.externalSecret.name | string | `"pull-secret"` | ExternalSecret CR name and the Secret it creates (default pull-secret). |
+| image.externalSecret.secretStoreRef | object | `{"kind":"ClusterSecretStore","name":"fairwinds-vault-backend"}` | SecretStore reference |
+| image.externalSecret.annotations | object | `{}` | Extra annotations on the ExternalSecret resource (e.g. argocd.argoproj.io/sync-wave) |
+| image.externalSecret.data | list | `[]` | ExternalSecret spec.data entries (required when create is true). Each needs `secretKey` and `remoteRef.key` (`property` optional). Use secretKey `.dockerconfigjson`. |
 | installationCode | string | `nil` | Installation code provided by Fairwinds. |
 | installationCodeSecret | string | `nil` | Name of secret containing INSTALLATION_CODE |
 | deployments | object | `{"additionalLabels":null,"additionalPodLabels":null}` | Deployments additional labels |
@@ -79,7 +86,12 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | cronjobs.cve-reports-email-sender | object | `{"command":"cve_reports_email_sender","schedule":"0 5 1 * *"}` | Options for the cve_reports_email_sender cronjob. |
 | cronjobs.refresh-jira-webhooks | object | `{"command":"refresh_jira_webhooks","schedule":"0 0 1,15 * *"}` | Options for the refresh_jira_webhooks cronjob |
 | cronjobs.utmstack-integration | object | `{"command":"utmstack_integration","schedule":"*/5 * * * *"}` | Options for the utmstack_integration cronjob |
-| selfHostedSecret | string | `nil` |  |
+| selfHostedSecret | object | `{"externalSecret":{"annotations":{},"create":false,"data":[],"name":"self-hosted-key","refreshInterval":"1h","secretStoreRef":{"kind":"ClusterSecretStore","name":"fairwinds-vault-backend"}}}` | Self-hosted TLS Secret (current.pem + pubkey). A string name still works. Set externalSecret.create to provision it via External Secrets Operator. |
+| selfHostedSecret.externalSecret.create | bool | `false` | When true, create an ExternalSecret that syncs into this Secret and mount it on API / admission / Temporal worker pods. |
+| selfHostedSecret.externalSecret.name | string | `"self-hosted-key"` | ExternalSecret CR name and the Secret it creates (default self-hosted-key). |
+| selfHostedSecret.externalSecret.secretStoreRef | object | `{"kind":"ClusterSecretStore","name":"fairwinds-vault-backend"}` | SecretStore reference |
+| selfHostedSecret.externalSecret.annotations | object | `{}` | Extra annotations on the ExternalSecret resource (e.g. argocd.argoproj.io/sync-wave) |
+| selfHostedSecret.externalSecret.data | list | `[]` | ExternalSecret spec.data entries (required when create is true). Each needs `secretKey` and `remoteRef.key` (`property` optional). |
 | additionalEnvironmentVariables | object | `{}` | Additional Environment Variables to set on the Fairwinds Insights pods. |
 | rbac.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | dashboard.pdb.enabled | bool | `false` | Create a pod disruption budget for the front end pods. |

--- a/stable/fairwinds-insights/templates/_env.yaml
+++ b/stable/fairwinds-insights/templates/_env.yaml
@@ -23,13 +23,14 @@ env:
   value: {{ $v | quote }}
 {{- end }}
 {{- end }}
-{{- with $.Values.selfHostedSecret }}
+{{- $selfHostedSecret := include "fairwinds-insights.selfHostedSecretName" $ | trim }}
+{{- if $selfHostedSecret }}
 - name: FAIRWINDS_CERTIFICATE_LOCATION
   value: /var/run/secrets/self-hosted/current.pem
 - name: SELF_HOSTED_PUBLIC_KEY
   valueFrom:
     secretKeyRef:
-      name: {{ . }}
+      name: {{ $selfHostedSecret }}
       key: pubkey
 {{- end }}
 {{- with $.Values.installationCode }}

--- a/stable/fairwinds-insights/templates/_helpers.tpl
+++ b/stable/fairwinds-insights/templates/_helpers.tpl
@@ -525,6 +525,44 @@ https://insights.fairwinds.com
 {{- end -}}
 
 {{/*
+Secret name for the self-hosted TLS key.
+String values.selfHostedSecret still works. ExternalSecret path: selfHostedSecret.externalSecret.name (default self-hosted-key) when create is true.
+*/}}
+{{- define "fairwinds-insights.selfHostedSecretName" -}}
+{{- $v := .Values.selfHostedSecret -}}
+{{- if kindIs "string" $v -}}
+{{- $v -}}
+{{- else -}}
+{{- $p := $v | default dict -}}
+{{- $ext := $p.externalSecret | default dict -}}
+{{- if $ext.create -}}
+{{- $ext.name | default "self-hosted-key" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Image pull Secret name.
+Existing path: image.pullSecret (string). ExternalSecret path: image.externalSecret.name (default pull-secret) when create is true.
+*/}}
+{{- define "fairwinds-insights.imagePullSecretName" -}}
+{{- $ext := .Values.image.externalSecret | default dict -}}
+{{- if $ext.create -}}
+{{- $ext.name | default "pull-secret" -}}
+{{- else if .Values.image.pullSecret -}}
+{{- .Values.image.pullSecret -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fairwinds-insights.imagePullSecrets" -}}
+{{- $name := include "fairwinds-insights.imagePullSecretName" . | trim -}}
+{{- if $name -}}
+imagePullSecrets:
+  - name: {{ $name }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Secret name for GCP pricing credentials.
 ESO path: externalSecret.name (default gcp-pricing-credentials-external).
 Existing Secret path: existingSecret (empty means do not mount).

--- a/stable/fairwinds-insights/templates/cronjobs.yaml
+++ b/stable/fairwinds-insights/templates/cronjobs.yaml
@@ -17,10 +17,7 @@ spec:
       template:
         spec:
           restartPolicy: OnFailure
-          {{- with $.Values.image.pullSecret }}
-          imagePullSecrets:
-            - name: {{ . }}
-          {{- end }}
+          {{- include "fairwinds-insights.imagePullSecrets" $ | nindent 10 }}
           serviceAccountName: {{ include "fairwinds-insights.fullname" $ }}-cronjob-executor
           containers:
             - name: {{ $name }}

--- a/stable/fairwinds-insights/templates/deployment-admission-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-admission-api.yaml
@@ -26,10 +26,7 @@ spec:
         {{ toYaml .Values.deployments.additionalPodLabels | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ . }}
-      {{- end }}
+      {{- include "fairwinds-insights.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "fairwinds-insights.fullname" . }}-insights
       containers:
         - name: fairwinds-insights
@@ -67,7 +64,8 @@ spec:
             mountPath: /.cache
           - name: secrets
             mountPath: /var/run/secrets/github
-          {{- if .Values.selfHostedSecret }}
+          {{- $selfHostedSecret := include "fairwinds-insights.selfHostedSecretName" . | trim }}
+          {{- if $selfHostedSecret }}
           - name: self-hosted-secret
             mountPath: /var/run/secrets/self-hosted
           {{- end }}
@@ -95,10 +93,11 @@ spec:
         secret:
           secretName: {{ .Values.admissionApi.githubSecret.name | default "github-secrets" }}
           optional: true
-      {{- with .Values.selfHostedSecret }}
+      {{- $selfHostedSecret := include "fairwinds-insights.selfHostedSecretName" . | trim }}
+      {{- if $selfHostedSecret }}
       - name: self-hosted-secret
         secret:
-          secretName: {{ . }}
+          secretName: {{ $selfHostedSecret }}
       {{- end }}
     {{- with .Values.admissionApi.tolerations }}
       tolerations:

--- a/stable/fairwinds-insights/templates/deployment-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-api.yaml
@@ -22,10 +22,7 @@ spec:
         {{ toYaml .Values.deployments.additionalPodLabels | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ . }}
-      {{- end }}
+      {{- include "fairwinds-insights.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "fairwinds-insights.fullname" . }}-insights
       containers:
         - name: fairwinds-insights
@@ -76,7 +73,8 @@ spec:
             mountPath: /.cache
           - name: secrets
             mountPath: /var/run/secrets/github
-          {{- if .Values.selfHostedSecret }}
+          {{- $selfHostedSecret := include "fairwinds-insights.selfHostedSecretName" . | trim }}
+          {{- if $selfHostedSecret }}
           - name: self-hosted-secret
             mountPath: /var/run/secrets/self-hosted
           {{- end }}
@@ -104,10 +102,11 @@ spec:
         secret:
           secretName: {{ .Values.api.githubSecret.name | default "github-secrets" }}
           optional: true
-      {{- with .Values.selfHostedSecret }}
+      {{- $selfHostedSecret := include "fairwinds-insights.selfHostedSecretName" . | trim }}
+      {{- if $selfHostedSecret }}
       - name: self-hosted-secret
         secret:
-          secretName: {{ . }}
+          secretName: {{ $selfHostedSecret }}
       {{- end }}
     {{- with .Values.api.tolerations }}
       tolerations:

--- a/stable/fairwinds-insights/templates/deployment-dashboard.yaml
+++ b/stable/fairwinds-insights/templates/deployment-dashboard.yaml
@@ -22,10 +22,7 @@ spec:
         {{ toYaml .Values.deployments.additionalPodLabels | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ . }}
-      {{- end }}
+      {{- include "fairwinds-insights.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: fw-insights-dashboard
           image: "{{ .Values.dashboardImage.repository }}:{{ include "fairwinds-insights.dashboardImageTag" . }}"

--- a/stable/fairwinds-insights/templates/deployment-mcp.yaml
+++ b/stable/fairwinds-insights/templates/deployment-mcp.yaml
@@ -40,10 +40,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with .Values.image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ . }}
-      {{- end }}
+      {{- include "fairwinds-insights.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "fairwinds-insights.fullname" . }}-insights
       automountServiceAccountToken: {{ .Values.mcp.automountServiceAccountToken }}
       {{- with .Values.mcp.priorityClassName }}

--- a/stable/fairwinds-insights/templates/deployment-open-api.yaml
+++ b/stable/fairwinds-insights/templates/deployment-open-api.yaml
@@ -22,10 +22,7 @@ spec:
         {{ toYaml .Values.deployments.additionalPodLabels | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ . }}
-      {{- end }}
+      {{- include "fairwinds-insights.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "fairwinds-insights.fullname" . }}-insights
       volumes:
       - name: nginx-conf

--- a/stable/fairwinds-insights/templates/deployment-outbox-worker.yaml
+++ b/stable/fairwinds-insights/templates/deployment-outbox-worker.yaml
@@ -34,10 +34,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with .Values.image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ . }}
-      {{- end }}
+      {{- include "fairwinds-insights.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "fairwinds-insights.fullname" . }}-insights
       terminationGracePeriodSeconds: {{ .Values.outboxWorker.terminationGracePeriodSeconds }}
       {{- with .Values.outboxWorker.priorityClassName }}

--- a/stable/fairwinds-insights/templates/deployment-report-job.yaml
+++ b/stable/fairwinds-insights/templates/deployment-report-job.yaml
@@ -27,10 +27,7 @@ spec:
         {{ toYaml .Values.deployments.additionalPodLabels | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ . }}
-      {{- end }}
+      {{- include "fairwinds-insights.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "fairwinds-insights.fullname" . }}-insights
       terminationGracePeriodSeconds: {{ .Values.reportjob.terminationGracePeriodSeconds }}
       containers:

--- a/stable/fairwinds-insights/templates/deployment-temporal-worker.yaml
+++ b/stable/fairwinds-insights/templates/deployment-temporal-worker.yaml
@@ -4,6 +4,7 @@
 {{- $gcpEnabled := and ($gcpPricing.enabled | default false) (eq $name "general-worker") }}
 {{- $gcpSecretName := include "fairwinds-insights.gcpPricingSecretName" $ | trim }}
 {{- $gcpMountCreds := and $gcpEnabled $gcpSecretName }}
+{{- $selfHostedSecret := include "fairwinds-insights.selfHostedSecretName" $ | trim }}
 {{- $gcpCredsKey := $gcpPricing.credentialsSecretKey | default "credentials.json" }}
 {{- $gcpCredsPath := $gcpPricing.credentialsMountPath | default "/var/run/secrets/gcp" }}
 apiVersion: apps/v1
@@ -49,10 +50,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with $.Values.image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ . }}
-      {{- end }}
+      {{- include "fairwinds-insights.imagePullSecrets" $ | nindent 6 }}
       {{- if (and $options.rbac $options.rbac.enabled) | default $.Values.temporalDeploymentDefaults.rbac.enabled }}
       serviceAccountName: {{ include "fairwinds-insights.fullname" $ }}-{{ $name }}
       {{- else }}
@@ -98,12 +96,12 @@ spec:
           securityContext:
             {{- toYaml (default $.Values.temporalDeploymentDefaults.securityContext $options.securityContext) | nindent 12 }}
           {{- $volumeMounts := default $.Values.temporalDeploymentDefaults.volumeMounts $options.volumeMounts }}
-          {{- if or $volumeMounts $.Values.selfHostedSecret $gcpMountCreds }}
+          {{- if or $volumeMounts $selfHostedSecret $gcpMountCreds }}
           volumeMounts:
             {{- with $volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- if $.Values.selfHostedSecret }}
+            {{- if $selfHostedSecret }}
             - name: self-hosted-secret
               mountPath: /var/run/secrets/self-hosted
             {{- end }}
@@ -130,15 +128,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $volumes := default $.Values.temporalDeploymentDefaults.volumes $options.volumes }}
-      {{- if or $volumes $.Values.selfHostedSecret $gcpMountCreds }}
+      {{- if or $volumes $selfHostedSecret $gcpMountCreds }}
       volumes:
         {{- with $volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if $.Values.selfHostedSecret }}
+        {{- if $selfHostedSecret }}
         - name: self-hosted-secret
           secret:
-            secretName: {{ $.Values.selfHostedSecret }}
+            secretName: {{ $selfHostedSecret }}
         {{- end }}
         {{- if $gcpMountCreds }}
         - name: gcp-pricing-credentials

--- a/stable/fairwinds-insights/templates/health-scores-migration.job.yaml
+++ b/stable/fairwinds-insights/templates/health-scores-migration.job.yaml
@@ -17,10 +17,7 @@ spec:
       template:
         spec:
           restartPolicy: Never
-          {{- with $.Values.image.pullSecret }}
-          imagePullSecrets:
-            - name: {{ . }}
-          {{- end }}
+          {{- include "fairwinds-insights.imagePullSecrets" $ | nindent 10 }}
           containers:
           - name: migrate-scores
             image: "{{ $.Values.cronjobImage.repository }}:{{ include "fairwinds-insights.cronjobImageTag" . }}"

--- a/stable/fairwinds-insights/templates/migrate-db-job.yaml
+++ b/stable/fairwinds-insights/templates/migrate-db-job.yaml
@@ -23,10 +23,7 @@ spec:
   template:
     spec:
       restartPolicy: Never
-      {{- with .Values.image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ . }}
-      {{- end }}
+      {{- include "fairwinds-insights.imagePullSecrets" . | nindent 6 }}
       initContainers:
       - name: wait-for-databases
         image: alpine/psql:18.3

--- a/stable/fairwinds-insights/templates/one-time-migration-job.yaml
+++ b/stable/fairwinds-insights/templates/one-time-migration-job.yaml
@@ -15,10 +15,7 @@ spec:
   template:
     spec:
       restartPolicy: Never
-      {{- with .Values.image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ . }}
-      {{- end }}
+      {{- include "fairwinds-insights.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: fwinsights-one-time-migration
         image: "{{ .Values.cronjobImage.repository }}:{{ include "fairwinds-insights.cronjobImageTag" . }}"

--- a/stable/fairwinds-insights/templates/pullsecret.externalsecret.yaml
+++ b/stable/fairwinds-insights/templates/pullsecret.externalsecret.yaml
@@ -1,0 +1,47 @@
+{{- $externalSecret := .Values.image.externalSecret | default dict }}
+{{- if $externalSecret.create }}
+{{- if .Values.image.pullSecret }}
+{{- fail "image.pullSecret and image.externalSecret.create cannot both be set; pick Existing (set pullSecret, create: false) or External (empty pullSecret, create: true)" }}
+{{- end }}
+{{- if not $externalSecret.data }}
+{{- fail "image.externalSecret.create is true but image.externalSecret.data is empty; provide at least one entry with secretKey and remoteRef.key (property optional)." }}
+{{- end }}
+{{- range $i, $entry := $externalSecret.data }}
+{{- if not $entry.secretKey }}
+{{- fail (printf "image.externalSecret.data[%d] is missing required field 'secretKey'" $i) }}
+{{- end }}
+{{- if not $entry.remoteRef }}
+{{- fail (printf "image.externalSecret.data[%d] is missing required field 'remoteRef'" $i) }}
+{{- end }}
+{{- if not $entry.remoteRef.key }}
+{{- fail (printf "image.externalSecret.data[%d].remoteRef is missing required field 'key'" $i) }}
+{{- end }}
+{{- end }}
+{{- $secretName := include "fairwinds-insights.imagePullSecretName" . | trim }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fairwinds-insights.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-10"
+  {{- with $externalSecret.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: {{ $externalSecret.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ $externalSecret.secretStoreRef.name }}
+    kind: {{ $externalSecret.secretStoreRef.kind }}
+  target:
+    name: {{ $secretName }}
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+  data:
+    {{- toYaml $externalSecret.data | nindent 4 }}
+{{- end }}

--- a/stable/fairwinds-insights/templates/selfhosted.externalsecret.yaml
+++ b/stable/fairwinds-insights/templates/selfhosted.externalsecret.yaml
@@ -1,0 +1,48 @@
+{{- $sh := .Values.selfHostedSecret | default dict }}
+{{- $externalSecret := dict }}
+{{- if kindIs "map" $sh }}
+{{- $externalSecret = $sh.externalSecret | default dict }}
+{{- end }}
+{{- if $externalSecret.create }}
+{{- if not $externalSecret.data }}
+{{- fail "selfHostedSecret.externalSecret.create is true but selfHostedSecret.externalSecret.data is empty; provide at least one entry with secretKey and remoteRef.key (property optional)." }}
+{{- end }}
+{{- range $i, $entry := $externalSecret.data }}
+{{- if not $entry.secretKey }}
+{{- fail (printf "selfHostedSecret.externalSecret.data[%d] is missing required field 'secretKey'" $i) }}
+{{- end }}
+{{- if not $entry.remoteRef }}
+{{- fail (printf "selfHostedSecret.externalSecret.data[%d] is missing required field 'remoteRef'" $i) }}
+{{- end }}
+{{- if not $entry.remoteRef.key }}
+{{- fail (printf "selfHostedSecret.externalSecret.data[%d].remoteRef is missing required field 'key'" $i) }}
+{{- end }}
+{{- end }}
+{{- $secretName := include "fairwinds-insights.selfHostedSecretName" . | trim }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fairwinds-insights.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-10"
+  {{- with $externalSecret.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: {{ $externalSecret.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ $externalSecret.secretStoreRef.name }}
+    kind: {{ $externalSecret.secretStoreRef.kind }}
+  target:
+    name: {{ $secretName }}
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    {{- toYaml $externalSecret.data | nindent 4 }}
+{{- end }}

--- a/stable/fairwinds-insights/templates/temporal-schedulers-job.yaml
+++ b/stable/fairwinds-insights/templates/temporal-schedulers-job.yaml
@@ -16,10 +16,7 @@ spec:
   template:
     spec:
       restartPolicy: Never
-      {{- with .Values.image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ . }}
-      {{- end }}
+      {{- include "fairwinds-insights.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: temporal-schedulers
         image: "{{ .Values.temporalSchedulersJob.image.repository }}:{{ .Values.temporalSchedulersJob.image.tag }}"

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -1,6 +1,30 @@
 image:
   # -- Docker image tag, defaults to the Chart appVersion
   tag:
+  # -- Existing dockerconfigjson Secret name for imagePullSecrets. Empty: none unless `externalSecret.create`. Invalid together with `externalSecret.create`.
+  pullSecret:
+  # -- ExternalSecret for the image pull Secret. Cannot be combined with `pullSecret`.
+  externalSecret:
+    # -- When true, create an ExternalSecret (type kubernetes.io/dockerconfigjson) and set imagePullSecrets on Insights workloads.
+    create: false
+    # -- ExternalSecret CR name and the Secret it creates (default pull-secret).
+    name: pull-secret
+    refreshInterval: 1h
+    # -- SecretStore reference
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: fairwinds-vault-backend
+    # -- Extra annotations on the ExternalSecret resource (e.g. argocd.argoproj.io/sync-wave)
+    annotations: {}
+    # -- ExternalSecret spec.data entries (required when create is true). Each needs `secretKey` and `remoteRef.key` (`property` optional). Use secretKey `.dockerconfigjson`.
+    data: []
+    # Example:
+    # data:
+    #   - secretKey: .dockerconfigjson
+    #     remoteRef:
+    #       key: my-infrastructure/my-cluster/insights/pull-secret
+    #       property: .dockerconfigjson
+
 
 # -- Installation code provided by Fairwinds.
 installationCode:
@@ -290,7 +314,33 @@ cronjobs:
     command: utmstack_integration
     schedule: "*/5 * * * *"
 
+# -- Self-hosted TLS Secret (current.pem + pubkey). A string name still works. Set externalSecret.create to provision it via External Secrets Operator.
 selfHostedSecret:
+  externalSecret:
+    # -- When true, create an ExternalSecret that syncs into this Secret and mount it on API / admission / Temporal worker pods.
+    create: false
+    # -- ExternalSecret CR name and the Secret it creates (default self-hosted-key).
+    name: self-hosted-key
+    refreshInterval: 1h
+    # -- SecretStore reference
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: fairwinds-vault-backend
+    # -- Extra annotations on the ExternalSecret resource (e.g. argocd.argoproj.io/sync-wave)
+    annotations: {}
+    # -- ExternalSecret spec.data entries (required when create is true). Each needs `secretKey` and `remoteRef.key` (`property` optional).
+    data: []
+    # Example:
+    # data:
+    #   - secretKey: current.pem
+    #     remoteRef:
+    #       key: my-infrastructure/my-cluster/insights/self-hosted
+    #       property: current.pem
+    #   - secretKey: pubkey
+    #     remoteRef:
+    #       key: my-infrastructure/my-cluster/insights/self-hosted
+    #       property: pubkey
+
 
 # -- Additional Environment Variables to set on the Fairwinds Insights pods.
 additionalEnvironmentVariables: {}


### PR DESCRIPTION


**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [x] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
