### PR TITLE
[stable/fairwinds-insights] Remove UTMStack integration support from the chart

### DIFF
--- a/stable/fairwinds-insights/CHANGELOG.md
+++ b/stable/fairwinds-insights/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 10.1.8
+* Remove UTMStack integration support (`cronjobs.utmstack-integration`)
+
 ## 10.1.7
 * Bumped `insights-api` to `18.4.30`
 

--- a/stable/fairwinds-insights/Chart.yaml
+++ b/stable/fairwinds-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "18.4.30"
 description: A Helm chart to run the Fairwinds Insights server
 name: fairwinds-insights
-version: 10.1.7
+version: 10.1.8
 kubeVersion: ">= 1.22.0-0"
 maintainers:
   - name: rbren

--- a/stable/fairwinds-insights/README.md
+++ b/stable/fairwinds-insights/README.md
@@ -85,7 +85,6 @@ See [insights.docs.fairwinds.com](https://insights.docs.fairwinds.com/technical-
 | cronjobs.app-groups-cves-statistics | object | `{"command":"app_groups_cves_statistics","schedule":"0 9,21 * * *"}` | Options for the app_groups_cves_statistics cronjob. |
 | cronjobs.cve-reports-email-sender | object | `{"command":"cve_reports_email_sender","schedule":"0 5 1 * *"}` | Options for the cve_reports_email_sender cronjob. |
 | cronjobs.refresh-jira-webhooks | object | `{"command":"refresh_jira_webhooks","schedule":"0 0 1,15 * *"}` | Options for the refresh_jira_webhooks cronjob |
-| cronjobs.utmstack-integration | object | `{"command":"utmstack_integration","schedule":"*/5 * * * *"}` | Options for the utmstack_integration cronjob |
 | selfHostedSecret | object | `{"externalSecret":{"annotations":{},"create":false,"data":[],"name":"self-hosted-key","refreshInterval":"1h","secretStoreRef":{"kind":"ClusterSecretStore","name":"fairwinds-vault-backend"}}}` | Self-hosted TLS Secret (current.pem + pubkey). A string name still works. Set externalSecret.create to provision it via External Secrets Operator. |
 | selfHostedSecret.externalSecret.create | bool | `false` | When true, create an ExternalSecret that syncs into this Secret and mount it on API / admission / Temporal worker pods. |
 | selfHostedSecret.externalSecret.name | string | `"self-hosted-key"` | ExternalSecret CR name and the Secret it creates (default self-hosted-key). |

--- a/stable/fairwinds-insights/values.yaml
+++ b/stable/fairwinds-insights/values.yaml
@@ -309,11 +309,6 @@ cronjobs:
     command: refresh_jira_webhooks
     schedule: "0 0 1,15 * *"
 
-  # -- Options for the utmstack_integration cronjob
-  utmstack-integration:
-    command: utmstack_integration
-    schedule: "*/5 * * * *"
-
 # -- Self-hosted TLS Secret (current.pem + pubkey). A string name still works. Set externalSecret.create to provision it via External Secrets Operator.
 selfHostedSecret:
   externalSecret:


### PR DESCRIPTION
**Why This PR?**
_a short description of why this PR is needed_

Fixes #

**Changes**
Changes proposed in this pull request:

*
*

**Checklist:**

* [X] I have included the name of the chart in the title of this PR in square brackets i.e. `[stable/goldilocks]`.
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] Any new values have been added to the README for the Chart, or `helm-docs --sort-values-order=file` has been run for the charts that support it.
